### PR TITLE
[R1281] Google pay core lib updates

### DIFF
--- a/ryft-core/src/main/java/com/ryftpay/android/core/api/payment/AttemptPaymentRequest.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/api/payment/AttemptPaymentRequest.kt
@@ -2,16 +2,33 @@ package com.ryftpay.android.core.api.payment
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.ryftpay.android.core.model.payment.PaymentMethod
+import com.ryftpay.android.core.model.payment.PaymentMethodType
+import java.lang.IllegalArgumentException
 
 data class AttemptPaymentRequest(
     @JsonProperty("clientSecret") val clientSecret: String,
-    @JsonProperty("cardDetails") val cardDetails: CardDetailsRequest
+    @JsonProperty("cardDetails") val cardDetails: CardDetailsRequest?,
+    @JsonProperty("walletDetails") val walletDetails: WalletDetailsRequest?
 ) {
     companion object {
         internal fun from(clientSecret: String, paymentMethod: PaymentMethod): AttemptPaymentRequest =
-            AttemptPaymentRequest(
-                clientSecret = clientSecret,
-                cardDetails = CardDetailsRequest.from(paymentMethod.cardDetails)
-            )
+            when (paymentMethod.type) {
+                PaymentMethodType.Card -> AttemptPaymentRequest(
+                    clientSecret = clientSecret,
+                    cardDetails = CardDetailsRequest.from(
+                        paymentMethod.cardDetails
+                            ?: throw IllegalArgumentException("Invalid payment method - card details is null")
+                    ),
+                    walletDetails = null
+                )
+                PaymentMethodType.GooglePay -> AttemptPaymentRequest(
+                    clientSecret = clientSecret,
+                    cardDetails = null,
+                    walletDetails = WalletDetailsRequest.from(
+                        paymentMethod.googlePayToken
+                            ?: throw IllegalArgumentException("Invalid payment method - google pay token is null")
+                    )
+                )
+            }
     }
 }

--- a/ryft-core/src/main/java/com/ryftpay/android/core/api/payment/WalletDetailsRequest.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/api/payment/WalletDetailsRequest.kt
@@ -1,0 +1,18 @@
+package com.ryftpay.android.core.api.payment
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class WalletDetailsRequest(
+    @JsonProperty("type") val type: String,
+    @JsonProperty("googlePayToken") val googlePayToken: String
+) {
+    companion object {
+        private const val GOOGLE_PAY_WALLET_TYPE = "GooglePay"
+
+        internal fun from(googlePayToken: String): WalletDetailsRequest =
+            WalletDetailsRequest(
+                GOOGLE_PAY_WALLET_TYPE,
+                googlePayToken
+            )
+    }
+}

--- a/ryft-core/src/main/java/com/ryftpay/android/core/model/payment/PaymentMethod.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/model/payment/PaymentMethod.kt
@@ -1,11 +1,21 @@
 package com.ryftpay.android.core.model.payment
 
 data class PaymentMethod(
-    val cardDetails: CardDetails
+    val type: PaymentMethodType,
+    val cardDetails: CardDetails?,
+    val googlePayToken: String?
 ) {
     companion object {
         fun card(cardDetails: CardDetails) = PaymentMethod(
-            cardDetails = cardDetails
+            type = PaymentMethodType.Card,
+            cardDetails = cardDetails,
+            googlePayToken = null
+        )
+
+        fun googlePay(googlePayToken: String) = PaymentMethod(
+            type = PaymentMethodType.GooglePay,
+            cardDetails = null,
+            googlePayToken = googlePayToken
         )
     }
 }

--- a/ryft-core/src/main/java/com/ryftpay/android/core/model/payment/PaymentMethodType.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/model/payment/PaymentMethodType.kt
@@ -1,0 +1,6 @@
+package com.ryftpay.android.core.model.payment
+
+enum class PaymentMethodType {
+    Card,
+    GooglePay
+}

--- a/ryft-core/src/test/java/com/ryftpay/android/core/TestData.kt
+++ b/ryft-core/src/test/java/com/ryftpay/android/core/TestData.kt
@@ -6,7 +6,6 @@ import com.ryftpay.android.core.api.payment.PaymentSessionResponse
 import com.ryftpay.android.core.api.payment.RequiredActionResponse
 import com.ryftpay.android.core.model.api.RyftPublicApiKey
 import com.ryftpay.android.core.model.payment.CardDetails
-import com.ryftpay.android.core.model.payment.PaymentMethod
 import com.ryftpay.android.core.model.payment.PaymentSessionStatus
 import com.ryftpay.android.core.model.payment.RequiredActionType
 import java.util.UUID
@@ -19,6 +18,7 @@ internal object TestData {
     internal const val SANDBOX_PUBLIC_API_KEY_VALUE = "pk_sandbox_123"
     internal const val SUB_ACCOUNT_ID = "ac_123"
     internal const val LAST_PAYMENT_ERROR = "invalid_card_number"
+    internal const val GOOGLE_PAY_TOKEN = "google_pay_token_123"
 
     internal val prodPublicApiKey = RyftPublicApiKey(PROD_PUBLIC_API_KEY_VALUE)
     internal val sandboxPublicApiKey = RyftPublicApiKey(SANDBOX_PUBLIC_API_KEY_VALUE)
@@ -29,8 +29,6 @@ internal object TestData {
         expiryYear = "2030",
         cvc = "100"
     )
-
-    internal val cardPaymentMethod = PaymentMethod(cardDetails)
 
     internal val ryftErrorElementResponse = RyftErrorElementResponse(
         code = "unexpected_error",

--- a/ryft-core/src/test/java/com/ryftpay/android/core/api/payment/AttemptPaymentRequestTest.kt
+++ b/ryft-core/src/test/java/com/ryftpay/android/core/api/payment/AttemptPaymentRequestTest.kt
@@ -1,9 +1,13 @@
 package com.ryftpay.android.core.api.payment
 
 import com.ryftpay.android.core.TestData.CLIENT_SECRET
-import com.ryftpay.android.core.TestData.cardPaymentMethod
+import com.ryftpay.android.core.TestData.GOOGLE_PAY_TOKEN
+import com.ryftpay.android.core.TestData.cardDetails
+import com.ryftpay.android.core.model.payment.PaymentMethod
+import com.ryftpay.android.core.model.payment.PaymentMethodType
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
+import java.lang.IllegalArgumentException
 
 internal class AttemptPaymentRequestTest {
 
@@ -11,7 +15,7 @@ internal class AttemptPaymentRequestTest {
     fun `from should return expected client secret`() {
         AttemptPaymentRequest.from(
             CLIENT_SECRET,
-            cardPaymentMethod
+            PaymentMethod.card(cardDetails)
         ).clientSecret shouldBeEqualTo CLIENT_SECRET
     }
 
@@ -19,7 +23,47 @@ internal class AttemptPaymentRequestTest {
     fun `from should add card details when payment method is card`() {
         AttemptPaymentRequest.from(
             CLIENT_SECRET,
-            cardPaymentMethod
-        ).cardDetails shouldBeEqualTo CardDetailsRequest.from(cardPaymentMethod.cardDetails)
+            PaymentMethod.card(cardDetails)
+        ).cardDetails shouldBeEqualTo CardDetailsRequest.from(cardDetails)
+    }
+
+    @Test
+    fun `from should not add wallet details when payment method is card`() {
+        AttemptPaymentRequest.from(
+            CLIENT_SECRET,
+            PaymentMethod.card(cardDetails)
+        ).walletDetails shouldBeEqualTo null
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `from should throw exception when card payment method has no card details`() {
+        AttemptPaymentRequest.from(
+            CLIENT_SECRET,
+            PaymentMethod(PaymentMethodType.Card, cardDetails = null, googlePayToken = null)
+        )
+    }
+
+    @Test
+    fun `from should add wallet details when payment method is google pay`() {
+        AttemptPaymentRequest.from(
+            CLIENT_SECRET,
+            PaymentMethod.googlePay(GOOGLE_PAY_TOKEN)
+        ).walletDetails shouldBeEqualTo WalletDetailsRequest.from(GOOGLE_PAY_TOKEN)
+    }
+
+    @Test
+    fun `from should not add card details when payment method is google pay`() {
+        AttemptPaymentRequest.from(
+            CLIENT_SECRET,
+            PaymentMethod.googlePay(GOOGLE_PAY_TOKEN)
+        ).cardDetails shouldBeEqualTo null
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `from should throw exception when google pay payment method has no google pay token`() {
+        AttemptPaymentRequest.from(
+            CLIENT_SECRET,
+            PaymentMethod(PaymentMethodType.GooglePay, cardDetails = null, googlePayToken = null)
+        )
     }
 }

--- a/ryft-core/src/test/java/com/ryftpay/android/core/api/payment/WalletDetailsRequestTest.kt
+++ b/ryft-core/src/test/java/com/ryftpay/android/core/api/payment/WalletDetailsRequestTest.kt
@@ -1,0 +1,15 @@
+package com.ryftpay.android.core.api.payment
+
+import com.ryftpay.android.core.TestData.GOOGLE_PAY_TOKEN
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+internal class WalletDetailsRequestTest {
+
+    @Test
+    fun `from should return expected fields`() {
+        val request = WalletDetailsRequest.from(GOOGLE_PAY_TOKEN)
+        request.type shouldBeEqualTo "GooglePay"
+        request.googlePayToken shouldBeEqualTo GOOGLE_PAY_TOKEN
+    }
+}

--- a/ryft-core/src/test/java/com/ryftpay/android/core/model/payment/PaymentMethodTest.kt
+++ b/ryft-core/src/test/java/com/ryftpay/android/core/model/payment/PaymentMethodTest.kt
@@ -1,5 +1,6 @@
 package com.ryftpay.android.core.model.payment
 
+import com.ryftpay.android.core.TestData.GOOGLE_PAY_TOKEN
 import com.ryftpay.android.core.TestData.cardDetails
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
@@ -9,5 +10,30 @@ internal class PaymentMethodTest {
     @Test
     fun `card should return a payment method with card details`() {
         PaymentMethod.card(cardDetails).cardDetails shouldBeEqualTo cardDetails
+    }
+
+    @Test
+    fun `card should return a payment method with type card`() {
+        PaymentMethod.card(cardDetails).type shouldBeEqualTo PaymentMethodType.Card
+    }
+
+    @Test
+    fun `card should return a payment method with no google pay token`() {
+        PaymentMethod.card(cardDetails).googlePayToken shouldBeEqualTo null
+    }
+
+    @Test
+    fun `googlePay should return a payment method with card details`() {
+        PaymentMethod.googlePay(GOOGLE_PAY_TOKEN).cardDetails shouldBeEqualTo null
+    }
+
+    @Test
+    fun `googlePay should return a payment method with type card`() {
+        PaymentMethod.googlePay(GOOGLE_PAY_TOKEN).type shouldBeEqualTo PaymentMethodType.GooglePay
+    }
+
+    @Test
+    fun `googlePay should return a payment method with no google pay token`() {
+        PaymentMethod.googlePay(GOOGLE_PAY_TOKEN).googlePayToken shouldBeEqualTo GOOGLE_PAY_TOKEN
     }
 }

--- a/ryft-core/src/test/java/com/ryftpay/android/core/service/DefaultRyftPaymentServiceTest.kt
+++ b/ryft-core/src/test/java/com/ryftpay/android/core/service/DefaultRyftPaymentServiceTest.kt
@@ -5,7 +5,7 @@ import com.ryftpay.android.core.TestData.CLIENT_SECRET
 import com.ryftpay.android.core.TestData.LAST_PAYMENT_ERROR
 import com.ryftpay.android.core.TestData.PAYMENT_SESSION_ID
 import com.ryftpay.android.core.TestData.SUB_ACCOUNT_ID
-import com.ryftpay.android.core.TestData.cardPaymentMethod
+import com.ryftpay.android.core.TestData.cardDetails
 import com.ryftpay.android.core.TestData.paymentSessionResponse
 import com.ryftpay.android.core.TestData.requiredActionResponse
 import com.ryftpay.android.core.TestData.ryftErrorResponse
@@ -13,6 +13,7 @@ import com.ryftpay.android.core.api.payment.AttemptPaymentRequest
 import com.ryftpay.android.core.api.payment.PaymentSessionResponse
 import com.ryftpay.android.core.client.RyftApiClient
 import com.ryftpay.android.core.model.error.RyftError
+import com.ryftpay.android.core.model.payment.PaymentMethod
 import com.ryftpay.android.core.model.payment.PaymentSession
 import com.ryftpay.android.core.model.payment.PaymentSessionError
 import com.ryftpay.android.core.model.payment.PaymentSessionStatus
@@ -38,10 +39,11 @@ internal class DefaultRyftPaymentServiceTest {
         client,
         paymentListener
     )
+    private val paymentMethod = PaymentMethod.card(cardDetails)
 
     @Test
     fun `attemptPayment calls listener on attempting payment`() {
-        paymentService.attemptPayment(CLIENT_SECRET, cardPaymentMethod, subAccountId = null)
+        paymentService.attemptPayment(CLIENT_SECRET, paymentMethod, subAccountId = null)
 
         verify {
             paymentListener.onAttemptingPayment()
@@ -50,11 +52,11 @@ internal class DefaultRyftPaymentServiceTest {
 
     @Test
     fun `attemptPayment calls client without sub account id when sub account id is null`() {
-        paymentService.attemptPayment(CLIENT_SECRET, cardPaymentMethod, subAccountId = null)
+        paymentService.attemptPayment(CLIENT_SECRET, paymentMethod, subAccountId = null)
 
         val expected = AttemptPaymentRequest.from(
             CLIENT_SECRET,
-            cardPaymentMethod
+            paymentMethod
         )
 
         verify {
@@ -69,11 +71,11 @@ internal class DefaultRyftPaymentServiceTest {
 
     @Test
     fun `attemptPayment calls client with sub account id when sub account id is present`() {
-        paymentService.attemptPayment(CLIENT_SECRET, cardPaymentMethod, SUB_ACCOUNT_ID)
+        paymentService.attemptPayment(CLIENT_SECRET, paymentMethod, SUB_ACCOUNT_ID)
 
         val expected = AttemptPaymentRequest.from(
             CLIENT_SECRET,
-            cardPaymentMethod
+            paymentMethod
         )
 
         verify {
@@ -91,7 +93,7 @@ internal class DefaultRyftPaymentServiceTest {
         val exception = Exception("bang")
         givenAttemptPaymentThrows(exception)
 
-        paymentService.attemptPayment(CLIENT_SECRET, cardPaymentMethod, subAccountId = null)
+        paymentService.attemptPayment(CLIENT_SECRET, paymentMethod, subAccountId = null)
 
         verify {
             paymentListener.onError(error = null, exception)
@@ -103,7 +105,7 @@ internal class DefaultRyftPaymentServiceTest {
         val response = Response.error<PaymentSessionResponse>(500, ResponseBody.create(null, "injiojf-3"))
         this.givenAttemptPaymentReturns(response)
 
-        paymentService.attemptPayment(CLIENT_SECRET, cardPaymentMethod, subAccountId = null)
+        paymentService.attemptPayment(CLIENT_SECRET, paymentMethod, subAccountId = null)
 
         verify {
             paymentListener.onError(RyftError.Unknown, throwable = null)
@@ -118,7 +120,7 @@ internal class DefaultRyftPaymentServiceTest {
         )
         this.givenAttemptPaymentReturns(response)
 
-        paymentService.attemptPayment(CLIENT_SECRET, cardPaymentMethod, subAccountId = null)
+        paymentService.attemptPayment(CLIENT_SECRET, paymentMethod, subAccountId = null)
 
         verify {
             paymentListener.onError(RyftError.from(ryftErrorResponse), throwable = null)
@@ -133,7 +135,7 @@ internal class DefaultRyftPaymentServiceTest {
         val response = Response.success(unexpectedPayment)
         this.givenAttemptPaymentReturns(response)
 
-        paymentService.attemptPayment(CLIENT_SECRET, cardPaymentMethod, subAccountId = null)
+        paymentService.attemptPayment(CLIENT_SECRET, paymentMethod, subAccountId = null)
 
         verify {
             paymentListener.onError(RyftError.Unknown, throwable = null)
@@ -150,7 +152,7 @@ internal class DefaultRyftPaymentServiceTest {
         val response = Response.success(paymentWithUserError)
         this.givenAttemptPaymentReturns(response)
 
-        paymentService.attemptPayment(CLIENT_SECRET, cardPaymentMethod, subAccountId = null)
+        paymentService.attemptPayment(CLIENT_SECRET, paymentMethod, subAccountId = null)
 
         verify {
             paymentListener.onPaymentHasError(
@@ -171,7 +173,7 @@ internal class DefaultRyftPaymentServiceTest {
         val response = Response.success(paymentRequiringRedirect)
         this.givenAttemptPaymentReturns(response)
 
-        paymentService.attemptPayment(CLIENT_SECRET, cardPaymentMethod, subAccountId = null)
+        paymentService.attemptPayment(CLIENT_SECRET, paymentMethod, subAccountId = null)
 
         verify {
             paymentListener.onPaymentRequiresRedirect(
@@ -192,7 +194,7 @@ internal class DefaultRyftPaymentServiceTest {
         val response = Response.success(approvedPayment)
         this.givenAttemptPaymentReturns(response)
 
-        paymentService.attemptPayment(CLIENT_SECRET, cardPaymentMethod, subAccountId = null)
+        paymentService.attemptPayment(CLIENT_SECRET, paymentMethod, subAccountId = null)
 
         verify {
             paymentListener.onPaymentApproved(PaymentSession.from(approvedPayment))


### PR DESCRIPTION
- Update ryft-core to support google pay by updating domain & api objects to allow a google pay token to be provided to the API