### PR TITLE
[R1281] Google pay ready check

### DIFF
--- a/ryft-core/src/main/java/com/ryftpay/android/core/model/api/RyftEnvironment.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/model/api/RyftEnvironment.kt
@@ -1,6 +1,6 @@
 package com.ryftpay.android.core.model.api
 
-internal enum class RyftEnvironment {
+enum class RyftEnvironment {
     Sandbox,
     Prod
 }

--- a/ryft-core/src/main/java/com/ryftpay/android/core/model/api/RyftPublicApiKey.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/model/api/RyftPublicApiKey.kt
@@ -7,7 +7,7 @@ data class RyftPublicApiKey(
         require(value.startsWith(KEY_PREFIX)) { "The API key you have provided is invalid, please check you are using your public API key" }
     }
 
-    internal fun getEnvironment(): RyftEnvironment =
+    fun getEnvironment(): RyftEnvironment =
         if (value.startsWith(SANDBOX_KEY_PREFIX)) {
             RyftEnvironment.Sandbox
         } else RyftEnvironment.Prod

--- a/ryft-ui/build.gradle
+++ b/ryft-ui/build.gradle
@@ -39,13 +39,15 @@ android {
 dependencies {
     implementation(project(path: ":ryft-core"))
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.0'
+    implementation 'com.google.android.gms:play-services-wallet:19.1.0'
+    implementation 'com.google.android.material:material:1.5.0'
 
     testImplementation 'io.mockk:mockk:1.12.2'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.amshove.kluent:kluent-android:1.68'
+    testImplementation 'org.json:json:20210307'
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 
     androidTestImplementation 'androidx.fragment:fragment-testing:1.4.1'

--- a/ryft-ui/src/main/AndroidManifest.xml
+++ b/ryft-ui/src/main/AndroidManifest.xml
@@ -10,6 +10,9 @@
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.AppCompat.RyftTransparent" />
+        <meta-data
+            android:name="com.google.android.gms.wallet.api.enabled"
+            android:value="true" />
     </application>
 
 </manifest>

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/delegate/DefaultRyftPaymentDelegate.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/delegate/DefaultRyftPaymentDelegate.kt
@@ -23,7 +23,7 @@ internal class DefaultRyftPaymentDelegate(
     private lateinit var body: RyftPaymentFormBody
     private lateinit var footer: RyftPaymentFormFooter
 
-    override fun onViewCreated(root: View) {
+    override fun onViewCreated(root: View, showGooglePay: Boolean) {
         cardOnlyHeader = root.findViewById(R.id.partial_ryft_payment_form_card_only_header)
         cardOnlyHeader.initialise()
         googlePayHeader = root.findViewById(R.id.partial_ryft_payment_form_googlepay_header)
@@ -32,7 +32,7 @@ internal class DefaultRyftPaymentDelegate(
         body.initialise(listener = this)
         footer = root.findViewById(R.id.partial_ryft_payment_form_footer)
         footer.initialise(listener = this)
-        showCardOnlyHeader()
+        setHeaderVisibility(showGooglePay)
     }
 
     override fun onCardReadyForPayment() {
@@ -64,9 +64,8 @@ internal class DefaultRyftPaymentDelegate(
         listener.onPayByGooglePay()
     }
 
-    // TODO add method to show the google pay header, called when it's available
-    private fun showCardOnlyHeader() {
-        cardOnlyHeader.visibility = View.VISIBLE
-        googlePayHeader.visibility = View.GONE
+    private fun setHeaderVisibility(showGooglePay: Boolean) {
+        cardOnlyHeader.visibility = if (showGooglePay) View.GONE else View.VISIBLE
+        googlePayHeader.visibility = if (showGooglePay) View.VISIBLE else View.GONE
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/delegate/RyftPaymentDelegate.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/delegate/RyftPaymentDelegate.kt
@@ -3,5 +3,5 @@ package com.ryftpay.android.ui.delegate
 import android.view.View
 
 internal interface RyftPaymentDelegate {
-    fun onViewCreated(root: View)
+    fun onViewCreated(root: View, showGooglePay: Boolean)
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/extension/RyftEnvironmentExtension.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/extension/RyftEnvironmentExtension.kt
@@ -1,0 +1,10 @@
+package com.ryftpay.android.ui.extension
+
+import com.google.android.gms.wallet.WalletConstants
+import com.ryftpay.android.core.model.api.RyftEnvironment
+
+internal fun RyftEnvironment.toGooglePayEnvironment(): Int =
+    when (this) {
+        RyftEnvironment.Prod -> WalletConstants.ENVIRONMENT_PRODUCTION
+        else -> WalletConstants.ENVIRONMENT_TEST
+    }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/model/RyftCardType.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/model/RyftCardType.kt
@@ -8,7 +8,9 @@ internal enum class RyftCardType(
     val cvcLength: Int,
     val cardNumberFormatGaps: IntArray,
     val binRanges: List<RyftCardBinRange>,
-    val iconDrawableId: Int
+    val iconDrawableId: Int,
+    val availableForGooglePay: Boolean,
+    val googlePayName: String
 ) {
     Visa(
         displayName = "Visa",
@@ -16,7 +18,9 @@ internal enum class RyftCardType(
         cvcLength = 3,
         cardNumberFormatGaps = intArrayOf(4, 8, 12),
         binRanges = listOf(RyftCardBinRange(min = 4, max = 4)),
-        iconDrawableId = R.drawable.ic_ryft_visa
+        iconDrawableId = R.drawable.ic_ryft_visa,
+        availableForGooglePay = true,
+        googlePayName = "VISA"
     ),
     Mastercard(
         displayName = "Mastercard",
@@ -27,7 +31,9 @@ internal enum class RyftCardType(
             RyftCardBinRange(min = 2221, max = 2720),
             RyftCardBinRange(min = 51, max = 55)
         ),
-        iconDrawableId = R.drawable.ic_ryft_mastercard
+        iconDrawableId = R.drawable.ic_ryft_mastercard,
+        availableForGooglePay = true,
+        googlePayName = "MASTERCARD"
     ),
     Amex(
         displayName = "American Express",
@@ -38,7 +44,9 @@ internal enum class RyftCardType(
             RyftCardBinRange(min = 34, max = 34),
             RyftCardBinRange(min = 37, max = 37)
         ),
-        iconDrawableId = R.drawable.ic_ryft_amex
+        iconDrawableId = R.drawable.ic_ryft_amex,
+        availableForGooglePay = false,
+        googlePayName = "AMEX"
     ),
     Unknown(
         displayName = "Unknown",
@@ -46,7 +54,9 @@ internal enum class RyftCardType(
         cvcLength = 4,
         cardNumberFormatGaps = intArrayOf(),
         binRanges = listOf(),
-        iconDrawableId = R.drawable.ic_ryft_unknown_card
+        iconDrawableId = R.drawable.ic_ryft_unknown_card,
+        availableForGooglePay = false,
+        googlePayName = "INVALID"
     );
 
     internal val maxFormattedCardLength = cardLengths.maxOf { it } + cardNumberFormatGaps.count()
@@ -60,5 +70,8 @@ internal enum class RyftCardType(
                 matchingCardTypes.first()
             } else Unknown
         }
+
+        internal fun getGooglePaySupportedTypeNames(): List<String> =
+            values().filter { it.availableForGooglePay }.map { it.googlePayName }
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/model/RyftCardType.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/model/RyftCardType.kt
@@ -10,7 +10,7 @@ internal enum class RyftCardType(
     val binRanges: List<RyftCardBinRange>,
     val iconDrawableId: Int,
     val availableForGooglePay: Boolean,
-    val googlePayName: String
+    val googlePayName: String?
 ) {
     Visa(
         displayName = "Visa",
@@ -56,7 +56,7 @@ internal enum class RyftCardType(
         binRanges = listOf(),
         iconDrawableId = R.drawable.ic_ryft_unknown_card,
         availableForGooglePay = false,
-        googlePayName = "INVALID"
+        googlePayName = null
     );
 
     internal val maxFormattedCardLength = cardLengths.maxOf { it } + cardNumberFormatGaps.count()
@@ -72,6 +72,8 @@ internal enum class RyftCardType(
         }
 
         internal fun getGooglePaySupportedTypeNames(): List<String> =
-            values().filter { it.availableForGooglePay }.map { it.googlePayName }
+            values()
+                .filter { it.availableForGooglePay }
+                .mapNotNull { it.googlePayName }
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/service/DefaultGooglePayService.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/service/DefaultGooglePayService.kt
@@ -1,0 +1,48 @@
+package com.ryftpay.android.ui.service
+
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.wallet.IsReadyToPayRequest
+import com.google.android.gms.wallet.PaymentsClient
+import com.ryftpay.android.ui.model.RyftCardType
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal class DefaultGooglePayService(
+    private val paymentsClient: PaymentsClient
+) : GooglePayService {
+
+    override fun isReadyToPay(): Task<Boolean> {
+        return paymentsClient.isReadyToPay(isReadyToPayRequest)
+    }
+
+    private val baseRequest: JSONObject = JSONObject()
+        .put("apiVersion", MAJOR_API_VERSION)
+        .put("apiVersionMinor", MINOR_API_VERSION)
+
+    private val cardPaymentMethod: JSONObject = JSONObject()
+        .put("type", CARD_PAYMENT_METHOD)
+        .put(
+            "parameters",
+            JSONObject()
+                .put("allowedAuthMethods", JSONArray(SUPPORTED_AUTH_METHODS))
+                .put("allowedCardNetworks", JSONArray(RyftCardType.getGooglePaySupportedTypeNames()))
+        )
+
+    private val allowedPaymentMethods: JSONArray = JSONArray()
+        .put(cardPaymentMethod)
+
+    private val isReadyToPayRequest: IsReadyToPayRequest = IsReadyToPayRequest.fromJson(
+        baseRequest.apply {
+            put("existingPaymentMethodRequired", IS_EXISTING_PAYMENT_METHOD_REQUIRED)
+                .put("allowedPaymentMethods", allowedPaymentMethods)
+        }.toString()
+    )
+
+    companion object {
+        private const val MAJOR_API_VERSION = 2
+        private const val MINOR_API_VERSION = 0
+        private const val CARD_PAYMENT_METHOD = "CARD"
+        private const val IS_EXISTING_PAYMENT_METHOD_REQUIRED = true
+        private val SUPPORTED_AUTH_METHODS = arrayOf("PAN_ONLY", "CRYPTOGRAM_3DS")
+    }
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/service/GooglePayService.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/service/GooglePayService.kt
@@ -1,0 +1,7 @@
+package com.ryftpay.android.ui.service
+
+import com.google.android.gms.tasks.Task
+
+internal interface GooglePayService {
+    fun isReadyToPay(): Task<Boolean>
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/service/PaymentsClientFactory.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/service/PaymentsClientFactory.kt
@@ -1,0 +1,20 @@
+package com.ryftpay.android.ui.service
+
+import android.app.Activity
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.android.gms.wallet.Wallet
+import com.ryftpay.android.core.model.api.RyftEnvironment
+import com.ryftpay.android.ui.extension.toGooglePayEnvironment
+
+internal object PaymentsClientFactory {
+
+    fun createPaymentsClient(
+        ryftEnvironment: RyftEnvironment,
+        activity: Activity
+    ): PaymentsClient = Wallet.getPaymentsClient(
+        activity,
+        Wallet.WalletOptions.Builder()
+            .setEnvironment(ryftEnvironment.toGooglePayEnvironment())
+            .build()
+    )
+}

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/extension/RyftEnvironmentExtensionTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/extension/RyftEnvironmentExtensionTest.kt
@@ -1,0 +1,27 @@
+package com.ryftpay.android.ui.extension
+
+import com.google.android.gms.wallet.WalletConstants
+import com.ryftpay.android.core.model.api.RyftEnvironment
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(JUnitParamsRunner::class)
+internal class RyftEnvironmentExtensionTest {
+
+    @Test
+    @Parameters(method = "ryftEnvironmentsToGooglePayEnvironments")
+    internal fun `toGooglePayEnvironment should return expected integer`(
+        ryftEnvironment: RyftEnvironment,
+        expected: Int
+    ) {
+        ryftEnvironment.toGooglePayEnvironment() shouldBeEqualTo expected
+    }
+
+    private fun ryftEnvironmentsToGooglePayEnvironments(): Array<Any> = arrayOf(
+        arrayOf(RyftEnvironment.Prod, WalletConstants.ENVIRONMENT_PRODUCTION),
+        arrayOf(RyftEnvironment.Sandbox, WalletConstants.ENVIRONMENT_TEST)
+    )
+}

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/model/RyftCardTypeTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/model/RyftCardTypeTest.kt
@@ -20,6 +20,8 @@ internal class RyftCardTypeTest {
         visa.binRanges shouldBeEqualTo listOf(RyftCardBinRange(min = 4, max = 4))
         visa.iconDrawableId shouldBeEqualTo R.drawable.ic_ryft_visa
         visa.maxFormattedCardLength shouldBeEqualTo 19
+        visa.availableForGooglePay shouldBeEqualTo true
+        visa.googlePayName shouldBeEqualTo "VISA"
     }
 
     @Test
@@ -35,6 +37,8 @@ internal class RyftCardTypeTest {
         )
         mastercard.iconDrawableId shouldBeEqualTo R.drawable.ic_ryft_mastercard
         mastercard.maxFormattedCardLength shouldBeEqualTo 19
+        mastercard.availableForGooglePay shouldBeEqualTo true
+        mastercard.googlePayName shouldBeEqualTo "MASTERCARD"
     }
 
     @Test
@@ -50,6 +54,8 @@ internal class RyftCardTypeTest {
         )
         amex.iconDrawableId shouldBeEqualTo R.drawable.ic_ryft_amex
         amex.maxFormattedCardLength shouldBeEqualTo 17
+        amex.availableForGooglePay shouldBeEqualTo false
+        amex.googlePayName shouldBeEqualTo "AMEX"
     }
 
     @Test
@@ -62,6 +68,8 @@ internal class RyftCardTypeTest {
         unknown.binRanges shouldBeEqualTo listOf()
         unknown.iconDrawableId shouldBeEqualTo R.drawable.ic_ryft_unknown_card
         unknown.maxFormattedCardLength shouldBeEqualTo 19
+        unknown.availableForGooglePay shouldBeEqualTo false
+        unknown.googlePayName shouldBeEqualTo "INVALID"
     }
 
     @Test
@@ -94,6 +102,11 @@ internal class RyftCardTypeTest {
         amexCardNumber: String
     ) {
         RyftCardType.fromCardNumber(amexCardNumber) shouldBeEqualTo RyftCardType.Amex
+    }
+
+    @Test
+    internal fun `getGooglePaySupportedTypeNames should return visa and mastercard`() {
+        RyftCardType.getGooglePaySupportedTypeNames() shouldBeEqualTo listOf("VISA", "MASTERCARD")
     }
 
     private fun unknownCardNumbers(): Array<String> = arrayOf(

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/model/RyftCardTypeTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/model/RyftCardTypeTest.kt
@@ -69,7 +69,7 @@ internal class RyftCardTypeTest {
         unknown.iconDrawableId shouldBeEqualTo R.drawable.ic_ryft_unknown_card
         unknown.maxFormattedCardLength shouldBeEqualTo 19
         unknown.availableForGooglePay shouldBeEqualTo false
-        unknown.googlePayName shouldBeEqualTo "INVALID"
+        unknown.googlePayName shouldBeEqualTo null
     }
 
     @Test

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/service/DefaultGooglePayServiceTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/service/DefaultGooglePayServiceTest.kt
@@ -1,0 +1,30 @@
+package com.ryftpay.android.ui.service
+
+import com.google.android.gms.wallet.PaymentsClient
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+internal class DefaultGooglePayServiceTest {
+
+    private val isReadyToPayRequestJson = DefaultGooglePayServiceTest::class.java
+        .getResource("/assets/googlepay/is-ready-to-pay-request.json")
+        ?.readText()
+        ?.replace(Regex("\\s+"), "")
+
+    private val client = mockk<PaymentsClient>(relaxed = true)
+    private val service = DefaultGooglePayService(client)
+
+    @Test
+    fun `isReadyToPay sends expected request`() {
+        service.isReadyToPay()
+
+        verify {
+            client.isReadyToPay(
+                match {
+                    it.toJson() == isReadyToPayRequestJson
+                }
+            )
+        }
+    }
+}

--- a/ryft-ui/src/test/resources/assets/googlepay/is-ready-to-pay-request.json
+++ b/ryft-ui/src/test/resources/assets/googlepay/is-ready-to-pay-request.json
@@ -1,0 +1,14 @@
+{
+  "apiVersionMinor": 0,
+  "apiVersion": 2,
+  "allowedPaymentMethods": [
+    {
+      "type": "CARD",
+      "parameters": {
+        "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+        "allowedCardNetworks": ["VISA", "MASTERCARD"]
+      }
+    }
+  ],
+  "existingPaymentMethodRequired": true
+}


### PR DESCRIPTION
- Add google pay wallet dependency and implement isReadyToPay request, powering whether or not we show google pay on the payment fragment

Google pay not available:
![image](https://user-images.githubusercontent.com/81687680/165988634-427ee953-8eff-4ac3-9381-d2a57cb27b64.png)

Google pay available:
![image](https://user-images.githubusercontent.com/81687680/165988788-3029f382-2765-41c2-9796-e5fe07d2b541.png)
