### PR TITLE
[R1281] Google pay error handling

### DIFF
--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/extension/FragmentExtension.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/extension/FragmentExtension.kt
@@ -1,6 +1,6 @@
 package com.ryftpay.android.ui.extension
 
-import android.app.AlertDialog
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import com.ryftpay.ui.R
 
@@ -10,7 +10,7 @@ internal fun Fragment.showAlertWithRetry(
     retryCallback: () -> Unit,
     cancelCallback: () -> Unit
 ) {
-    AlertDialog.Builder(requireContext())
+    AlertDialog.Builder(requireContext(), R.style.RyftAlertDialog)
         .setTitle(title)
         .setMessage(message)
         .setPositiveButton(getString(R.string.ryft_retry)) { _, _ ->

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/extension/FragmentExtension.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/extension/FragmentExtension.kt
@@ -1,0 +1,28 @@
+package com.ryftpay.android.ui.extension
+
+import android.app.AlertDialog
+import androidx.fragment.app.Fragment
+import com.ryftpay.ui.R
+
+internal fun Fragment.showAlertWithRetry(
+    title: String? = null,
+    message: String? = null,
+    retryCallback: () -> Unit,
+    cancelCallback: () -> Unit
+) {
+    AlertDialog.Builder(requireContext())
+        .setTitle(title)
+        .setMessage(message)
+        .setPositiveButton(getString(R.string.ryft_retry)) { _, _ ->
+            retryCallback()
+        }
+        .setNegativeButton(getString(R.string.ryft_cancel)) { dialog, _ ->
+            dialog.dismiss()
+            cancelCallback()
+        }
+        .setOnCancelListener {
+            cancelCallback()
+        }
+        .create()
+        .show()
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/fragment/RyftPaymentFragment.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/fragment/RyftPaymentFragment.kt
@@ -32,6 +32,7 @@ import com.ryftpay.android.ui.delegate.RyftPaymentDelegate
 import com.ryftpay.android.ui.dropin.RyftDropInConfiguration
 import com.ryftpay.android.ui.dropin.RyftPaymentError
 import com.ryftpay.android.ui.dropin.RyftPaymentResult
+import com.ryftpay.android.ui.extension.showAlertWithRetry
 import com.ryftpay.android.ui.listener.RyftPaymentFormListener
 import com.ryftpay.android.ui.model.RyftCard
 import com.ryftpay.android.ui.model.googlepay.GooglePayResult
@@ -181,10 +182,11 @@ internal class RyftPaymentFragment :
         error: RyftError?,
         throwable: Throwable?
     ) {
-        paymentResultViewModel.updateResult(
-            RyftPaymentResult.Failed(RyftPaymentError.from(throwable, requireContext()))
+        showAlertWithRetry(
+            message = getString(R.string.ryft_google_pay_error_message),
+            retryCallback = { onPayByGooglePay() },
+            cancelCallback = { delegate.onGooglePayFailedOrCancelled() }
         )
-        safeDismiss()
     }
 
     override fun onPaymentLoaded(response: PaymentSession) {

--- a/ryft-ui/src/main/res/values-en/strings.xml
+++ b/ryft-ui/src/main/res/values-en/strings.xml
@@ -7,11 +7,13 @@
     <string name="ryft_pay">Pay now</string>
     <string name="ryft_taking_payment">Taking payment…</string>
     <string name="ryft_or">or</string>
+    <string name="ryft_retry">Retry</string>
     <string name="ryft_cancel">Cancel</string>
     <string name="ryft_card_number">Card number</string>
     <string name="ryft_card_expiry_date">MM/YY</string>
     <string name="ryft_card_cvc">CVC</string>
     <string name="ryft_payment_form_card_only_header_title">Credit / Debit Card</string>
+    <string name="ryft_google_pay_error_message">Error loading Google Pay</string>
 
     <string name="ryft_bad_track_data">Your CVC or card expiration is invalid</string>
     <string name="ryft_declined_do_not_honour">Your bank has declined this card</string>

--- a/ryft-ui/src/main/res/values-night/colors.xml
+++ b/ryft-ui/src/main/res/values-night/colors.xml
@@ -17,5 +17,6 @@
     <color name="ryftDivider">#4E5156</color>
     <color name="ryftDividerText">#949494</color>
     <color name="ryftBackground">#303030</color>
+    <color name="ryftAlertDialogButtonText">#2581E3</color>
 
 </resources>

--- a/ryft-ui/src/main/res/values/colors.xml
+++ b/ryft-ui/src/main/res/values/colors.xml
@@ -17,5 +17,6 @@
     <color name="ryftDivider">#1A000000</color>
     <color name="ryftDividerText">#939393</color>
     <color name="ryftBackground">#FAFAFA</color>
+    <color name="ryftAlertDialogButtonText">#2581E3</color>
 
 </resources>

--- a/ryft-ui/src/main/res/values/strings.xml
+++ b/ryft-ui/src/main/res/values/strings.xml
@@ -7,11 +7,13 @@
     <string name="ryft_pay">Pay now</string>
     <string name="ryft_taking_payment">Taking payment…</string>
     <string name="ryft_or">or</string>
+    <string name="ryft_retry">Retry</string>
     <string name="ryft_cancel">Cancel</string>
     <string name="ryft_card_number">Card number</string>
     <string name="ryft_card_expiry_date">MM/YY</string>
     <string name="ryft_card_cvc">CVC</string>
     <string name="ryft_payment_form_card_only_header_title">Credit / Debit Card</string>
+    <string name="ryft_google_pay_error_message">Error loading Google Pay</string>
 
     <string name="ryft_bad_track_data">Your CVC or card expiration is invalid</string>
     <string name="ryft_declined_do_not_honour">Your bank has declined this card</string>

--- a/ryft-ui/src/main/res/values/styles.xml
+++ b/ryft-ui/src/main/res/values/styles.xml
@@ -7,6 +7,19 @@
         <item name="android:windowSoftInputMode">adjustResize</item>
     </style>
 
+    <style name="RyftAlertDialog" parent="ThemeOverlay.AppCompat.Dialog.Alert">
+        <item name="buttonBarNegativeButtonStyle">@style/RyftAlertDialogNegativeButtonStyle</item>
+        <item name="buttonBarPositiveButtonStyle">@style/RyftAlertDialogPositiveButtonStyle</item>
+    </style>
+
+    <style name="RyftAlertDialogNegativeButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+        <item name="android:textColor">@color/ryftAlertDialogButtonText</item>
+    </style>
+
+    <style name="RyftAlertDialogPositiveButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+        <item name="android:textColor">@color/ryftAlertDialogButtonText</item>
+    </style>
+
     <style name="RyftFullscreenDialog">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowFullscreen">false</item>


### PR DESCRIPTION
- DIsplay internal alert dialog if the call to get the payment session fails prior to google pay, rather than returning to the client

Dark mode:
![Screenshot_20220517-101242](https://user-images.githubusercontent.com/81687680/168780572-cdc2f12e-7f22-4703-ad37-ac78ebddfef3.png)
Light mode:
![Screenshot_20220517-101320](https://user-images.githubusercontent.com/81687680/168780582-295eb771-17bb-4e5c-8b83-18367bc13e28.png)

