### PR TITLE
[R1281] Google pay billing address

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ class CheckoutFragment : Fragment() {
                 subAccountId = null || "<the Id of the sub-account you are taking payments for>",
                 googlePayConfiguration = RyftDropInGooglePayConfiguration(
                     merchantName = "<The name of your business>",
-                    merchantCountryCode = "<The ISO 3166-1 alpha-2 country code of your business>",
-                    billingAddressRequired = false //Optional flag, defaults to true
+                    merchantCountryCode = "<The ISO 3166-1 alpha-2 country code of your business>"
                 )
             )
         )

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ class CheckoutFragment : Fragment() {
                 googlePayConfiguration = RyftDropInGooglePayConfiguration(
                     merchantName = "<The name of your business>",
                     merchantCountryCode = "<The ISO 3166-1 alpha-2 country code of your business>",
-                    billingAddressRequired = true //Optional flag, defaults to false
+                    billingAddressRequired = false //Optional flag, defaults to true
                 )
             )
         )

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ class CheckoutFragment : Fragment() {
                 subAccountId = null || "<the Id of the sub-account you are taking payments for>",
                 googlePayConfiguration = RyftDropInGooglePayConfiguration(
                     merchantName = "<The name of your business>",
-                    merchantCountryCode = "<The ISO 3166-1 alpha-2 country code of your business>"
+                    merchantCountryCode = "<The ISO 3166-1 alpha-2 country code of your business>",
+                    billingAddressRequired = true //Optional flag, defaults to false
                 )
             )
         )

--- a/ryft-core/src/main/java/com/ryftpay/android/core/api/payment/AttemptPaymentRequest.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/api/payment/AttemptPaymentRequest.kt
@@ -8,26 +8,29 @@ import java.lang.IllegalArgumentException
 data class AttemptPaymentRequest(
     @JsonProperty("clientSecret") val clientSecret: String,
     @JsonProperty("cardDetails") val cardDetails: CardDetailsRequest?,
-    @JsonProperty("walletDetails") val walletDetails: WalletDetailsRequest?
+    @JsonProperty("walletDetails") val walletDetails: WalletDetailsRequest?,
+    @JsonProperty("billingAddress") val billingAddress: BillingAddressRequest?
 ) {
     companion object {
         internal fun from(clientSecret: String, paymentMethod: PaymentMethod): AttemptPaymentRequest =
             when (paymentMethod.type) {
                 PaymentMethodType.Card -> AttemptPaymentRequest(
-                    clientSecret = clientSecret,
-                    cardDetails = CardDetailsRequest.from(
+                    clientSecret,
+                    CardDetailsRequest.from(
                         paymentMethod.cardDetails
                             ?: throw IllegalArgumentException("Invalid payment method - card details is null")
                     ),
-                    walletDetails = null
+                    walletDetails = null,
+                    BillingAddressRequest.from(paymentMethod.billingAddress)
                 )
                 PaymentMethodType.GooglePay -> AttemptPaymentRequest(
-                    clientSecret = clientSecret,
+                    clientSecret,
                     cardDetails = null,
-                    walletDetails = WalletDetailsRequest.from(
+                    WalletDetailsRequest.from(
                         paymentMethod.googlePayToken
                             ?: throw IllegalArgumentException("Invalid payment method - google pay token is null")
-                    )
+                    ),
+                    BillingAddressRequest.from(paymentMethod.billingAddress)
                 )
             }
     }

--- a/ryft-core/src/main/java/com/ryftpay/android/core/api/payment/BillingAddressRequest.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/api/payment/BillingAddressRequest.kt
@@ -1,0 +1,33 @@
+package com.ryftpay.android.core.api.payment
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.ryftpay.android.core.model.payment.Address
+
+data class BillingAddressRequest(
+    @JsonProperty("firstName") val firstName: String?,
+    @JsonProperty("lastName") val lastName: String?,
+    @JsonProperty("lineOne") val lineOne: String?,
+    @JsonProperty("lineTwo") val lineTwo: String?,
+    @JsonProperty("city") val city: String?,
+    @JsonProperty("country") val country: String,
+    @JsonProperty("postalCode") val postalCode: String,
+    @JsonProperty("region") val region: String?,
+) {
+    companion object {
+        internal fun from(billingAddress: Address?): BillingAddressRequest? =
+            if (billingAddress == null) {
+                null
+            } else {
+                BillingAddressRequest(
+                    billingAddress.firstName,
+                    billingAddress.lastName,
+                    billingAddress.lineOne,
+                    billingAddress.lineTwo,
+                    billingAddress.city,
+                    billingAddress.country,
+                    billingAddress.postalCode,
+                    billingAddress.region
+                )
+            }
+    }
+}

--- a/ryft-core/src/main/java/com/ryftpay/android/core/model/payment/Address.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/model/payment/Address.kt
@@ -1,0 +1,12 @@
+package com.ryftpay.android.core.model.payment
+
+data class Address(
+    val firstName: String?,
+    val lastName: String?,
+    val lineOne: String?,
+    val lineTwo: String?,
+    val city: String?,
+    val country: String,
+    val postalCode: String,
+    val region: String?
+)

--- a/ryft-core/src/main/java/com/ryftpay/android/core/model/payment/PaymentMethod.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/model/payment/PaymentMethod.kt
@@ -3,19 +3,22 @@ package com.ryftpay.android.core.model.payment
 data class PaymentMethod(
     val type: PaymentMethodType,
     val cardDetails: CardDetails?,
-    val googlePayToken: String?
+    val googlePayToken: String?,
+    val billingAddress: Address?
 ) {
     companion object {
         fun card(cardDetails: CardDetails) = PaymentMethod(
             type = PaymentMethodType.Card,
-            cardDetails = cardDetails,
-            googlePayToken = null
+            cardDetails,
+            googlePayToken = null,
+            billingAddress = null
         )
 
-        fun googlePay(googlePayToken: String) = PaymentMethod(
+        fun googlePay(googlePayToken: String, billingAddress: Address?) = PaymentMethod(
             type = PaymentMethodType.GooglePay,
             cardDetails = null,
-            googlePayToken = googlePayToken
+            googlePayToken,
+            billingAddress
         )
     }
 }

--- a/ryft-core/src/test/java/com/ryftpay/android/core/TestData.kt
+++ b/ryft-core/src/test/java/com/ryftpay/android/core/TestData.kt
@@ -5,6 +5,7 @@ import com.ryftpay.android.core.api.error.RyftErrorResponse
 import com.ryftpay.android.core.api.payment.PaymentSessionResponse
 import com.ryftpay.android.core.api.payment.RequiredActionResponse
 import com.ryftpay.android.core.model.api.RyftPublicApiKey
+import com.ryftpay.android.core.model.payment.Address
 import com.ryftpay.android.core.model.payment.CardDetails
 import com.ryftpay.android.core.model.payment.PaymentSessionStatus
 import com.ryftpay.android.core.model.payment.RequiredActionType
@@ -28,6 +29,17 @@ internal object TestData {
         expiryMonth = "10",
         expiryYear = "2030",
         cvc = "100"
+    )
+
+    internal val address = Address(
+        firstName = "John",
+        lastName = "Doe",
+        lineOne = "c/o Google LLC",
+        lineTwo = "1600 Amphitheatre Pkwy",
+        city = "Mountain View",
+        country = "US",
+        postalCode = "94043",
+        region = "CA"
     )
 
     internal val ryftErrorElementResponse = RyftErrorElementResponse(

--- a/ryft-core/src/test/java/com/ryftpay/android/core/api/payment/AttemptPaymentRequestTest.kt
+++ b/ryft-core/src/test/java/com/ryftpay/android/core/api/payment/AttemptPaymentRequestTest.kt
@@ -2,6 +2,7 @@ package com.ryftpay.android.core.api.payment
 
 import com.ryftpay.android.core.TestData.CLIENT_SECRET
 import com.ryftpay.android.core.TestData.GOOGLE_PAY_TOKEN
+import com.ryftpay.android.core.TestData.address
 import com.ryftpay.android.core.TestData.cardDetails
 import com.ryftpay.android.core.model.payment.PaymentMethod
 import com.ryftpay.android.core.model.payment.PaymentMethodType
@@ -39,15 +40,41 @@ internal class AttemptPaymentRequestTest {
     fun `from should throw exception when card payment method has no card details`() {
         AttemptPaymentRequest.from(
             CLIENT_SECRET,
-            PaymentMethod(PaymentMethodType.Card, cardDetails = null, googlePayToken = null)
+            PaymentMethod(
+                PaymentMethodType.Card,
+                cardDetails = null,
+                googlePayToken = null,
+                billingAddress = null
+            )
         )
+    }
+
+    @Test
+    fun `from should not add billing address when card payment method has none`() {
+        AttemptPaymentRequest.from(
+            CLIENT_SECRET,
+            PaymentMethod.card(cardDetails)
+        ).billingAddress shouldBeEqualTo null
+    }
+
+    @Test
+    fun `from should add billing address when card payment method has one`() {
+        AttemptPaymentRequest.from(
+            CLIENT_SECRET,
+            PaymentMethod(
+                type = PaymentMethodType.Card,
+                cardDetails,
+                googlePayToken = null,
+                billingAddress = address
+            )
+        ).billingAddress shouldBeEqualTo BillingAddressRequest.from(address)
     }
 
     @Test
     fun `from should add wallet details when payment method is google pay`() {
         AttemptPaymentRequest.from(
             CLIENT_SECRET,
-            PaymentMethod.googlePay(GOOGLE_PAY_TOKEN)
+            PaymentMethod.googlePay(GOOGLE_PAY_TOKEN, billingAddress = null)
         ).walletDetails shouldBeEqualTo WalletDetailsRequest.from(GOOGLE_PAY_TOKEN)
     }
 
@@ -55,7 +82,7 @@ internal class AttemptPaymentRequestTest {
     fun `from should not add card details when payment method is google pay`() {
         AttemptPaymentRequest.from(
             CLIENT_SECRET,
-            PaymentMethod.googlePay(GOOGLE_PAY_TOKEN)
+            PaymentMethod.googlePay(GOOGLE_PAY_TOKEN, billingAddress = null)
         ).cardDetails shouldBeEqualTo null
     }
 
@@ -63,7 +90,28 @@ internal class AttemptPaymentRequestTest {
     fun `from should throw exception when google pay payment method has no google pay token`() {
         AttemptPaymentRequest.from(
             CLIENT_SECRET,
-            PaymentMethod(PaymentMethodType.GooglePay, cardDetails = null, googlePayToken = null)
+            PaymentMethod(
+                PaymentMethodType.GooglePay,
+                cardDetails = null,
+                googlePayToken = null,
+                billingAddress = null
+            )
         )
+    }
+
+    @Test
+    fun `from should not add billing address when google pay payment method has none`() {
+        AttemptPaymentRequest.from(
+            CLIENT_SECRET,
+            PaymentMethod.googlePay(GOOGLE_PAY_TOKEN, billingAddress = null)
+        ).billingAddress shouldBeEqualTo null
+    }
+
+    @Test
+    fun `from should add billing address when google pay payment method has one`() {
+        AttemptPaymentRequest.from(
+            CLIENT_SECRET,
+            PaymentMethod.googlePay(GOOGLE_PAY_TOKEN, billingAddress = address)
+        ).billingAddress shouldBeEqualTo BillingAddressRequest.from(address)
     }
 }

--- a/ryft-core/src/test/java/com/ryftpay/android/core/api/payment/BillingAddressRequestTest.kt
+++ b/ryft-core/src/test/java/com/ryftpay/android/core/api/payment/BillingAddressRequestTest.kt
@@ -1,0 +1,51 @@
+package com.ryftpay.android.core.api.payment
+
+import com.ryftpay.android.core.TestData.address
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.junit.Test
+
+internal class BillingAddressRequestTest {
+
+    @Test
+    fun `from should return null when provided null`() {
+        BillingAddressRequest.from(billingAddress = null) shouldBeEqualTo null
+    }
+
+    @Test
+    fun `from should return all fields when address has all fields`() {
+        val request = BillingAddressRequest.from(address)
+        request shouldNotBeEqualTo null
+        request!!.firstName shouldBeEqualTo address.firstName
+        request.lastName shouldBeEqualTo address.lastName
+        request.lineOne shouldBeEqualTo address.lineOne
+        request.lineTwo shouldBeEqualTo address.lineTwo
+        request.city shouldBeEqualTo address.city
+        request.country shouldBeEqualTo address.country
+        request.postalCode shouldBeEqualTo address.postalCode
+        request.region shouldBeEqualTo address.region
+    }
+
+    @Test
+    fun `from should return non null fields when address only has those fields set`() {
+        val request = BillingAddressRequest.from(
+            address.copy(
+                firstName = null,
+                lastName = null,
+                lineOne = null,
+                lineTwo = null,
+                city = null,
+                region = null
+            )
+        )
+        request shouldNotBeEqualTo null
+        request!!.firstName shouldBeEqualTo null
+        request.lastName shouldBeEqualTo null
+        request.lineOne shouldBeEqualTo null
+        request.lineTwo shouldBeEqualTo null
+        request.city shouldBeEqualTo null
+        request.country shouldBeEqualTo address.country
+        request.postalCode shouldBeEqualTo address.postalCode
+        request.region shouldBeEqualTo null
+    }
+}

--- a/ryft-core/src/test/java/com/ryftpay/android/core/model/payment/PaymentMethodTest.kt
+++ b/ryft-core/src/test/java/com/ryftpay/android/core/model/payment/PaymentMethodTest.kt
@@ -1,6 +1,7 @@
 package com.ryftpay.android.core.model.payment
 
 import com.ryftpay.android.core.TestData.GOOGLE_PAY_TOKEN
+import com.ryftpay.android.core.TestData.address
 import com.ryftpay.android.core.TestData.cardDetails
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
@@ -23,17 +24,47 @@ internal class PaymentMethodTest {
     }
 
     @Test
-    fun `googlePay should return a payment method with card details`() {
-        PaymentMethod.googlePay(GOOGLE_PAY_TOKEN).cardDetails shouldBeEqualTo null
+    fun `card should return a payment method with no billing address`() {
+        PaymentMethod.card(cardDetails).billingAddress shouldBeEqualTo null
+    }
+
+    @Test
+    fun `googlePay should return a payment method with no card details`() {
+        PaymentMethod.googlePay(
+            GOOGLE_PAY_TOKEN,
+            billingAddress = null
+        ).cardDetails shouldBeEqualTo null
     }
 
     @Test
     fun `googlePay should return a payment method with type card`() {
-        PaymentMethod.googlePay(GOOGLE_PAY_TOKEN).type shouldBeEqualTo PaymentMethodType.GooglePay
+        PaymentMethod.googlePay(
+            GOOGLE_PAY_TOKEN,
+            billingAddress = null
+        ).type shouldBeEqualTo PaymentMethodType.GooglePay
     }
 
     @Test
     fun `googlePay should return a payment method with no google pay token`() {
-        PaymentMethod.googlePay(GOOGLE_PAY_TOKEN).googlePayToken shouldBeEqualTo GOOGLE_PAY_TOKEN
+        PaymentMethod.googlePay(
+            GOOGLE_PAY_TOKEN,
+            billingAddress = null
+        ).googlePayToken shouldBeEqualTo GOOGLE_PAY_TOKEN
+    }
+
+    @Test
+    fun `googlePay should return a payment method with no billing address when none provided`() {
+        PaymentMethod.googlePay(
+            GOOGLE_PAY_TOKEN,
+            billingAddress = null
+        ).billingAddress shouldBeEqualTo null
+    }
+
+    @Test
+    fun `googlePay should return a payment method with billing address when one provided`() {
+        PaymentMethod.googlePay(
+            GOOGLE_PAY_TOKEN,
+            billingAddress = address
+        ).billingAddress shouldBeEqualTo address
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfiguration.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfiguration.kt
@@ -6,6 +6,5 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class RyftDropInGooglePayConfiguration(
     val merchantName: String,
-    val merchantCountryCode: String,
-    val billingAddressRequired: Boolean = true
+    val merchantCountryCode: String
 ) : Parcelable

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfiguration.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfiguration.kt
@@ -6,5 +6,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class RyftDropInGooglePayConfiguration(
     val merchantName: String,
-    val merchantCountryCode: String
+    val merchantCountryCode: String,
+    val billingAddressRequired: Boolean = false
 ) : Parcelable

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfiguration.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfiguration.kt
@@ -7,5 +7,5 @@ import kotlinx.parcelize.Parcelize
 data class RyftDropInGooglePayConfiguration(
     val merchantName: String,
     val merchantCountryCode: String,
-    val billingAddressRequired: Boolean = false
+    val billingAddressRequired: Boolean = true
 ) : Parcelable

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/extension/StringExtension.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/extension/StringExtension.kt
@@ -1,22 +1,21 @@
 package com.ryftpay.android.ui.extension
 
+private val TITLES = arrayOf("MISS", "MR", "MRS", "MS")
+
 // Returns a string of digits if all characters are digits, else null
-internal fun String.toDigitsOrNull(): String? {
-    return if (!any() || any { !it.isDigit() }) {
-        null
-    } else this
-}
+internal fun String.toDigitsOrNull(): String? = if (!any() || any { !it.isDigit() }) {
+    null
+} else this
 
 // Overloaded method that also filters out any separators in the string
 internal fun String.toDigitsOrNull(filterSeparator: Char): String? =
     filter { it != filterSeparator }.toDigitsOrNull()
 
 // Adds a separator character to the given positions in the string
-internal fun String.addSeparatorIntoPositions(separator: Char, positions: IntArray): String {
+internal fun String.addSeparatorIntoPositions(separator: Char, positions: IntArray): String =
     if (!positions.any()) {
-        return this
-    }
-    return this.mapIndexed { index, c ->
+        this
+    } else this.mapIndexed { index, c ->
         val position = index + 1
         if (positions.contains(position)) {
             "$c$separator"
@@ -24,4 +23,16 @@ internal fun String.addSeparatorIntoPositions(separator: Char, positions: IntArr
             c.toString()
         }
     }.joinToString(separator = "")
+
+internal fun String?.extractFirstAndLastNamesOrNulls(): Pair<String?, String?> {
+    if (this == null) {
+        return Pair(null, null)
+    }
+    val names = this.split(" ").filter { !TITLES.contains(it.uppercase()) }
+    val firstName = names.firstOrNull()?.ifEmpty { null }
+    val lastName = names.drop(1).lastOrNull()?.ifEmpty { null }
+    return Pair(
+        firstName,
+        lastName
+    )
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/fragment/RyftPaymentFragment.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/fragment/RyftPaymentFragment.kt
@@ -194,7 +194,7 @@ internal class RyftPaymentFragment :
             activity = requireActivity(),
             loadPaymentDataRequest = LoadPaymentDataRequest(
                 MerchantInfo.from(input.configuration.googlePayConfiguration.merchantName),
-                input.configuration.googlePayConfiguration.billingAddressRequired,
+                GOOGLE_PAY_BILLING_ADDRESS_REQUIRED,
                 TokenizationSpecification.ryft(input.publicApiKey),
                 TransactionInfo.from(
                     response,
@@ -259,7 +259,7 @@ internal class RyftPaymentFragment :
         root: View
     ) {
         googlePayService.isReadyToPay(
-            input.configuration.googlePayConfiguration.billingAddressRequired
+            GOOGLE_PAY_BILLING_ADDRESS_REQUIRED
         ).addOnCompleteListener { completedTask ->
             run {
                 val showGooglePay = try {
@@ -303,5 +303,6 @@ internal class RyftPaymentFragment :
     companion object {
         @VisibleForTesting(otherwise = PRIVATE)
         internal const val ARGUMENTS_BUNDLE_KEY = "Arguments"
+        private const val GOOGLE_PAY_BILLING_ADDRESS_REQUIRED = true
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/fragment/RyftPaymentFragment.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/fragment/RyftPaymentFragment.kt
@@ -194,6 +194,7 @@ internal class RyftPaymentFragment :
             activity = requireActivity(),
             loadPaymentDataRequest = LoadPaymentDataRequest(
                 MerchantInfo.from(input.configuration.googlePayConfiguration.merchantName),
+                input.configuration.googlePayConfiguration.billingAddressRequired,
                 TokenizationSpecification.ryft(input.publicApiKey),
                 TransactionInfo.from(
                     response,
@@ -225,7 +226,10 @@ internal class RyftPaymentFragment :
                 delegate.onGooglePayPaymentProcessing()
                 ryftPaymentService.attemptPayment(
                     clientSecret = input.configuration.clientSecret,
-                    paymentMethod = PaymentMethod.googlePay(result.paymentData.token),
+                    paymentMethod = PaymentMethod.googlePay(
+                        result.paymentData.token,
+                        result.paymentData.billingAddress
+                    ),
                     subAccountId = input.configuration.subAccountId,
                     listener = this
                 )
@@ -254,7 +258,9 @@ internal class RyftPaymentFragment :
     private fun checkGooglePayBeforeInitialisingDelegate(
         root: View
     ) {
-        googlePayService.isReadyToPay().addOnCompleteListener { completedTask ->
+        googlePayService.isReadyToPay(
+            input.configuration.googlePayConfiguration.billingAddressRequired
+        ).addOnCompleteListener { completedTask ->
             run {
                 val showGooglePay = try {
                     completedTask.getResult(ApiException::class.java)

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/CardPaymentMethod.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/CardPaymentMethod.kt
@@ -7,19 +7,27 @@ import org.json.JSONObject
 internal class CardPaymentMethod : PaymentMethod() {
 
     override fun toApiV2RequestJson(
+        billingAddressRequired: Boolean,
         tokenizationSpecification: TokenizationSpecification?
     ): JSONObject {
+        val cardPaymentMethodParameters = JSONObject()
+            .put(ALLOWED_AUTH_METHODS_KEY, JSONArray(supportedAuthMethods))
+            .put(
+                ALLOWED_CARD_NETWORKS_KEY,
+                JSONArray(RyftCardType.getGooglePaySupportedTypeNames())
+            )
+        if (billingAddressRequired) {
+            cardPaymentMethodParameters
+                .put(BILLING_ADDRESS_REQUIRED_KEY, true)
+                .put(
+                    BILLING_ADDRESS_PARAMETERS_KEY,
+                    JSONObject()
+                        .put(BILLING_ADDRESS_FORMAT_KEY, FULL_BILLING_ADDRESS_FORMAT)
+                )
+        }
         val cardPaymentMethod = JSONObject()
             .put(TYPE_KEY, CARD_TYPE)
-            .put(
-                PARAMETERS_KEY,
-                JSONObject()
-                    .put(ALLOWED_AUTH_METHODS_KEY, JSONArray(supportedAuthMethods))
-                    .put(
-                        ALLOWED_CARD_NETWORKS_KEY,
-                        JSONArray(RyftCardType.getGooglePaySupportedTypeNames())
-                    )
-            )
+            .put(PARAMETERS_KEY, cardPaymentMethodParameters)
         if (tokenizationSpecification != null) {
             cardPaymentMethod.put(
                 TokenizationSpecification.KEY,
@@ -35,6 +43,10 @@ internal class CardPaymentMethod : PaymentMethod() {
         private const val PARAMETERS_KEY = "parameters"
         private const val ALLOWED_AUTH_METHODS_KEY = "allowedAuthMethods"
         private const val ALLOWED_CARD_NETWORKS_KEY = "allowedCardNetworks"
+        private const val BILLING_ADDRESS_REQUIRED_KEY = "billingAddressRequired"
+        private const val BILLING_ADDRESS_PARAMETERS_KEY = "billingAddressParameters"
+        private const val BILLING_ADDRESS_FORMAT_KEY = "format"
+        private const val FULL_BILLING_ADDRESS_FORMAT = "FULL"
         private val supportedAuthMethods = arrayOf("PAN_ONLY", "CRYPTOGRAM_3DS")
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/LoadPaymentDataRequest.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/LoadPaymentDataRequest.kt
@@ -5,6 +5,7 @@ import org.json.JSONObject
 
 internal data class LoadPaymentDataRequest(
     val merchantInfo: MerchantInfo,
+    val billingAddressRequired: Boolean,
     val tokenizationSpecification: TokenizationSpecification,
     val transactionInfo: TransactionInfo
 ) {
@@ -17,7 +18,12 @@ internal data class LoadPaymentDataRequest(
         put(
             PaymentMethod.ALLOWED_PAYMENT_METHODS_KEY,
             JSONArray()
-                .put(CardPaymentMethod().toApiV2RequestJson(tokenizationSpecification))
+                .put(
+                    CardPaymentMethod().toApiV2RequestJson(
+                        billingAddressRequired,
+                        tokenizationSpecification
+                    )
+                )
         )
         put(TransactionInfo.KEY, transactionInfo.toApiV2RequestJson())
     }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/PaymentDataResponse.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/PaymentDataResponse.kt
@@ -1,20 +1,44 @@
 package com.ryftpay.android.ui.model.googlepay
 
 import com.google.android.gms.wallet.PaymentData
+import com.ryftpay.android.core.model.payment.Address
+import com.ryftpay.android.ui.extension.extractFirstAndLastNamesOrNulls
 import org.json.JSONObject
 
 internal data class PaymentDataResponse(
-    val token: String
+    val token: String,
+    val billingAddress: Address?
 ) {
     companion object {
         internal fun from(paymentData: PaymentData): PaymentDataResponse {
             val json = JSONObject(paymentData.toJson())
             val paymentMethodJson = json.getJSONObject("paymentMethodData")
+            val cardInfoJson = paymentMethodJson.getJSONObject("info")
+            val billingAddressJson = cardInfoJson.optJSONObject("billingAddress")
             val token = paymentMethodJson
                 .getJSONObject("tokenizationData")
                 .get("token")
                 .toString()
-            return PaymentDataResponse(token)
+            return PaymentDataResponse(token, addressFrom(billingAddressJson))
+        }
+
+        private fun addressFrom(addressJson: JSONObject?): Address? {
+            if (addressJson == null) {
+                return null
+            }
+            val firstAndLastNames = addressJson
+                .optString("name")
+                .extractFirstAndLastNamesOrNulls()
+            return Address(
+                firstName = firstAndLastNames.first,
+                lastName = firstAndLastNames.second,
+                lineOne = addressJson.getString("address1").ifEmpty { null },
+                lineTwo = addressJson.optString("address2").ifEmpty { null },
+                city = addressJson.getString("locality").ifEmpty { null },
+                country = addressJson.getString("countryCode"),
+                postalCode = addressJson.getString("postalCode"),
+                region = addressJson.optString("administrativeArea").ifEmpty { null }
+            )
         }
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/PaymentMethod.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/PaymentMethod.kt
@@ -5,6 +5,7 @@ import org.json.JSONObject
 internal abstract class PaymentMethod {
 
     internal abstract fun toApiV2RequestJson(
+        billingAddressRequired: Boolean,
         tokenizationSpecification: TokenizationSpecification?
     ): JSONObject
 

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/ReadyToPayRequest.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/ReadyToPayRequest.kt
@@ -4,7 +4,8 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 internal data class ReadyToPayRequest(
-    val existingPaymentMethodRequired: Boolean = true
+    val existingPaymentMethodRequired: Boolean = true,
+    val billingAddressRequired: Boolean
 ) {
     internal fun toApiV2RequestJson(
         baseApiRequest: BaseApiRequest
@@ -16,7 +17,10 @@ internal data class ReadyToPayRequest(
             PaymentMethod.ALLOWED_PAYMENT_METHODS_KEY,
             JSONArray()
                 .put(
-                    CardPaymentMethod().toApiV2RequestJson(tokenizationSpecification = null)
+                    CardPaymentMethod().toApiV2RequestJson(
+                        billingAddressRequired,
+                        tokenizationSpecification = null
+                    )
                 )
         )
     }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/service/DefaultGooglePayService.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/service/DefaultGooglePayService.kt
@@ -19,9 +19,13 @@ internal class DefaultGooglePayService(
         minorApiVersion = 0
     )
 
-    override fun isReadyToPay(): Task<Boolean> = paymentsClient.isReadyToPay(
+    override fun isReadyToPay(
+        billingAddressRequired: Boolean
+    ): Task<Boolean> = paymentsClient.isReadyToPay(
         IsReadyToPayRequest.fromJson(
-            ReadyToPayRequest().toApiV2RequestJson(baseApiV2Request).toString()
+            ReadyToPayRequest(
+                billingAddressRequired = billingAddressRequired
+            ).toApiV2RequestJson(baseApiV2Request).toString()
         )
     )
 

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/service/GooglePayService.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/service/GooglePayService.kt
@@ -5,7 +5,9 @@ import com.google.android.gms.tasks.Task
 import com.ryftpay.android.ui.model.googlepay.LoadPaymentDataRequest
 
 internal interface GooglePayService {
-    fun isReadyToPay(): Task<Boolean>
+    fun isReadyToPay(
+        billingAddressRequired: Boolean
+    ): Task<Boolean>
     fun loadPaymentData(
         activity: Activity,
         loadPaymentDataRequest: LoadPaymentDataRequest

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/extension/StringExtensionTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/extension/StringExtensionTest.kt
@@ -58,6 +58,15 @@ internal class StringExtensionTest {
         input.addSeparatorIntoPositions(separator, positions) shouldBeEqualTo expected
     }
 
+    @Test
+    @Parameters(method = "fullNamesToExpectedPairs")
+    internal fun `extractFirstAndLastNamesOrNulls should return first and last name or a null pair`(
+        input: String?,
+        expected: Pair<String?, String?>
+    ) {
+        input.extractFirstAndLastNamesOrNulls() shouldBeEqualTo expected
+    }
+
     private fun stringsContainingNonDigits(): Array<Any> = arrayOf(
         arrayOf("iok0934"),
         arrayOf("abc"),
@@ -113,5 +122,58 @@ internal class StringExtensionTest {
         arrayOf("hello", intArrayOf(), "hello"),
         arrayOf("", intArrayOf(2), ""),
         arrayOf("no", intArrayOf(5), "no")
+    )
+
+    private fun fullNamesToExpectedPairs(): Array<Any> = arrayOf(
+        arrayOf(null, Pair<String?, String?>(null, null)),
+        arrayOf("", Pair<String?, String?>(null, null)),
+        arrayOf("John", Pair<String?, String?>("John", null)),
+        arrayOf("John ", Pair<String?, String?>("John", null)),
+        arrayOf("John Doe", Pair<String?, String?>("John", "Doe")),
+        arrayOf("John Bob Doe", Pair<String?, String?>("John", "Doe")),
+        arrayOf("John Bob-Doe", Pair<String?, String?>("John", "Bob-Doe")),
+        arrayOf("John Bob Bob-Doe", Pair<String?, String?>("John", "Bob-Doe")),
+        arrayOf("Miss Jenny Doe", Pair<String?, String?>("Jenny", "Doe")),
+        arrayOf("Mr John Doe", Pair<String?, String?>("John", "Doe")),
+        arrayOf("Mrs Jenny Doe", Pair<String?, String?>("Jenny", "Doe")),
+        arrayOf("Ms Jenny Doe", Pair<String?, String?>("Jenny", "Doe")),
+        arrayOf("Miss Jenny Sarah Doe", Pair<String?, String?>("Jenny", "Doe")),
+        arrayOf("Mr John Bob Doe", Pair<String?, String?>("John", "Doe")),
+        arrayOf("Mrs Jenny Sarah Doe", Pair<String?, String?>("Jenny", "Doe")),
+        arrayOf("Ms Jenny Sarah Doe", Pair<String?, String?>("Jenny", "Doe")),
+        arrayOf("Miss Jenny Sarah-Doe", Pair<String?, String?>("Jenny", "Sarah-Doe")),
+        arrayOf("Mr John Bob-Doe", Pair<String?, String?>("John", "Bob-Doe")),
+        arrayOf("Mrs Jenny Sarah-Doe", Pair<String?, String?>("Jenny", "Sarah-Doe")),
+        arrayOf("Ms Jenny Sarah-Doe", Pair<String?, String?>("Jenny", "Sarah-Doe")),
+        arrayOf("Miss J Doe", Pair<String?, String?>("J", "Doe")),
+        arrayOf("Mr J Doe", Pair<String?, String?>("J", "Doe")),
+        arrayOf("Mrs J Doe", Pair<String?, String?>("J", "Doe")),
+        arrayOf("Ms J Doe", Pair<String?, String?>("J", "Doe")),
+        arrayOf("Miss J S Doe", Pair<String?, String?>("J", "Doe")),
+        arrayOf("Mr J B Doe", Pair<String?, String?>("J", "Doe")),
+        arrayOf("Mrs J S Doe", Pair<String?, String?>("J", "Doe")),
+        arrayOf("Ms J S Doe", Pair<String?, String?>("J", "Doe")),
+        arrayOf("JOHN", Pair<String?, String?>("JOHN", null)),
+        arrayOf("JOHN ", Pair<String?, String?>("JOHN", null)),
+        arrayOf("JOHN DOE", Pair<String?, String?>("JOHN", "DOE")),
+        arrayOf("JOHN BOB DOE", Pair<String?, String?>("JOHN", "DOE")),
+        arrayOf("JOHN BOB-DOE", Pair<String?, String?>("JOHN", "BOB-DOE")),
+        arrayOf("JOHN BOB BOB-DOE", Pair<String?, String?>("JOHN", "BOB-DOE")),
+        arrayOf("MISS JENNY SARAH DOE", Pair<String?, String?>("JENNY", "DOE")),
+        arrayOf("MR JOHN BOB DOE", Pair<String?, String?>("JOHN", "DOE")),
+        arrayOf("MRS JENNY SARAH DOE", Pair<String?, String?>("JENNY", "DOE")),
+        arrayOf("MS JENNY SARAH DOE", Pair<String?, String?>("JENNY", "DOE")),
+        arrayOf("MISS JENNY SARAH-DOE", Pair<String?, String?>("JENNY", "SARAH-DOE")),
+        arrayOf("MR JOHN BOB-DOE", Pair<String?, String?>("JOHN", "BOB-DOE")),
+        arrayOf("MRS JENNY SARAH-DOE", Pair<String?, String?>("JENNY", "SARAH-DOE")),
+        arrayOf("MS JENNY SARAH-DOE", Pair<String?, String?>("JENNY", "SARAH-DOE")),
+        arrayOf("MISS J DOE", Pair<String?, String?>("J", "DOE")),
+        arrayOf("MR J DOE", Pair<String?, String?>("J", "DOE")),
+        arrayOf("MRS J DOE", Pair<String?, String?>("J", "DOE")),
+        arrayOf("MS J DOE", Pair<String?, String?>("J", "DOE")),
+        arrayOf("MISS J S DOE", Pair<String?, String?>("J", "DOE")),
+        arrayOf("MR J B DOE", Pair<String?, String?>("J", "DOE")),
+        arrayOf("MRS J S DOE", Pair<String?, String?>("J", "DOE")),
+        arrayOf("MS J S DOE", Pair<String?, String?>("J", "DOE"))
     )
 }

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/model/googlepay/CardPaymentMethodTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/model/googlepay/CardPaymentMethodTest.kt
@@ -12,14 +12,16 @@ internal class CardPaymentMethodTest {
     @Test
     fun `toApiV2RequestJson should return expected type`() {
         val requestJson = CardPaymentMethod().toApiV2RequestJson(
+            billingAddressRequired = false,
             tokenizationSpecification = null
         )
         requestJson.get("type") shouldBeEqualTo "CARD"
     }
 
     @Test
-    fun `toApiV2RequestJson should return expected parameters`() {
+    fun `toApiV2RequestJson should return expected parameters when billing address is not required`() {
         val requestJson = CardPaymentMethod().toApiV2RequestJson(
+            billingAddressRequired = false,
             tokenizationSpecification = null
         )
         requestJson.get("parameters").toString() shouldBeEqualTo JSONObject()
@@ -38,9 +40,38 @@ internal class CardPaymentMethodTest {
             .toString()
     }
 
+    @Test
+    fun `toApiV2RequestJson should return expected parameters when billing address is required`() {
+        val requestJson = CardPaymentMethod().toApiV2RequestJson(
+            billingAddressRequired = true,
+            tokenizationSpecification = null
+        )
+        requestJson.get("parameters").toString() shouldBeEqualTo JSONObject()
+            .put(
+                "allowedAuthMethods",
+                JSONArray()
+                    .put("PAN_ONLY")
+                    .put("CRYPTOGRAM_3DS")
+            )
+            .put(
+                "allowedCardNetworks",
+                JSONArray()
+                    .put("VISA")
+                    .put("MASTERCARD")
+            )
+            .put("billingAddressRequired", true)
+            .put(
+                "billingAddressParameters",
+                JSONObject()
+                    .put("format", "FULL")
+            )
+            .toString()
+    }
+
     @Test(expected = JSONException::class)
     fun `toApiV2RequestJson should not return tokenization specification when null`() {
         val requestJson = CardPaymentMethod().toApiV2RequestJson(
+            billingAddressRequired = false,
             tokenizationSpecification = null
         )
         requestJson.get("tokenizationSpecification")
@@ -49,6 +80,7 @@ internal class CardPaymentMethodTest {
     @Test
     fun `toApiV2RequestJson should return tokenization specification when provided`() {
         val requestJson = CardPaymentMethod().toApiV2RequestJson(
+            billingAddressRequired = false,
             ryftTokenizationSpecification
         )
         val expected = ryftTokenizationSpecification.toApiV2RequestJson().toString()

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/model/googlepay/LoadPaymentDataRequestTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/model/googlepay/LoadPaymentDataRequestTest.kt
@@ -11,6 +11,7 @@ internal class LoadPaymentDataRequestTest {
 
     private val loadPaymentDataRequest = LoadPaymentDataRequest(
         merchantInfo,
+        billingAddressRequired = false,
         ryftTokenizationSpecification,
         transactionInfo
     )
@@ -31,7 +32,27 @@ internal class LoadPaymentDataRequestTest {
     fun `toApiV2RequestJson returns json with a card payment method with input tokenization specification`() {
         val requestJson = loadPaymentDataRequest.toApiV2RequestJson(baseApiV2Request)
         requestJson.get("allowedPaymentMethods").toString() shouldBeEqualTo JSONArray()
-            .put(CardPaymentMethod().toApiV2RequestJson(ryftTokenizationSpecification))
+            .put(
+                CardPaymentMethod().toApiV2RequestJson(
+                    billingAddressRequired = false,
+                    ryftTokenizationSpecification
+                )
+            )
+            .toString()
+    }
+
+    @Test
+    fun `toApiV2RequestJson returns json with a card payment method with billing address required when it is`() {
+        val requestJson = loadPaymentDataRequest.copy(
+            billingAddressRequired = true
+        ).toApiV2RequestJson(baseApiV2Request)
+        requestJson.get("allowedPaymentMethods").toString() shouldBeEqualTo JSONArray()
+            .put(
+                CardPaymentMethod().toApiV2RequestJson(
+                    billingAddressRequired = true,
+                    ryftTokenizationSpecification
+                )
+            )
             .toString()
     }
 

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/model/googlepay/PaymentDataResponseTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/model/googlepay/PaymentDataResponseTest.kt
@@ -1,6 +1,7 @@
 package com.ryftpay.android.ui.model.googlepay
 
 import com.google.android.gms.wallet.PaymentData
+import com.ryftpay.android.core.model.payment.Address
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 
@@ -8,16 +9,66 @@ class PaymentDataResponseTest {
 
     private val paymentDataResponse = PaymentDataResponseTest::class.java
         .getResource("/assets/googlepay/payment-data-response.json")
-        ?.readText()
-        ?.replace(Regex("\\s+"), "") ?: ""
+        ?.readText() ?: ""
+
+    private val paymentDataResponseWithFullBillingAddress = PaymentDataResponseTest::class.java
+        .getResource("/assets/googlepay/payment-data-response-with-full-billing-address.json")
+        ?.readText() ?: ""
+
+    private val paymentDataResponseWithPartialBillingAddress = PaymentDataResponseTest::class.java
+        .getResource("/assets/googlepay/payment-data-response-with-partial-billing-address.json")
+        ?.readText() ?: ""
 
     @Test
-    fun `from should return expected fields`() {
+    fun `from should return expected fields when no billing address is present`() {
         val paymentDataResponse = PaymentDataResponse.from(
             PaymentData.fromJson(paymentDataResponse)
         )
         val expected = PaymentDataResponse(
-            token = "examplePaymentMethodToken"
+            token = "examplePaymentMethodToken",
+            billingAddress = null
+        )
+        paymentDataResponse shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `from should return expected fields when a full billing address is present`() {
+        val paymentDataResponse = PaymentDataResponse.from(
+            PaymentData.fromJson(paymentDataResponseWithFullBillingAddress)
+        )
+        val expected = PaymentDataResponse(
+            token = "examplePaymentMethodToken",
+            billingAddress = Address(
+                firstName = "John",
+                lastName = "Doe",
+                lineOne = "c/o Google LLC",
+                lineTwo = "1600 Amphitheatre Pkwy",
+                city = "Mountain View",
+                country = "US",
+                postalCode = "94043",
+                region = "CA"
+            )
+        )
+        paymentDataResponse shouldBeEqualTo expected
+    }
+
+    @Test
+    fun `from should return expected billing address when optional fields are null or empty`() {
+        val paymentDataResponse = PaymentDataResponse.from(
+            PaymentData.fromJson(paymentDataResponseWithPartialBillingAddress)
+        )
+        val expected = PaymentDataResponse(
+            token = "examplePaymentMethodToken",
+            billingAddress = Address(
+                firstName = null,
+                lastName = null,
+                lineOne = null,
+                lineTwo = null,
+                city = null,
+                country = "GB",
+                postalCode = "SW1A 2AA",
+                region = null
+            )
         )
         paymentDataResponse shouldBeEqualTo expected
     }

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/model/googlepay/ReadyToPayRequestTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/model/googlepay/ReadyToPayRequestTest.kt
@@ -13,28 +13,55 @@ internal class ReadyToPayRequestTest {
 
     @Test
     fun `toApiV2RequestJson returns json with api versions`() {
-        val requestJson = ReadyToPayRequest().toApiV2RequestJson(baseApiV2Request)
+        val requestJson = ReadyToPayRequest(
+            billingAddressRequired = false
+        ).toApiV2RequestJson(baseApiV2Request)
         requestJson.get("apiVersion") shouldBeEqualTo 2
         requestJson.get("apiVersionMinor") shouldBeEqualTo 0
     }
 
     @Test
     fun `toApiV2RequestJson returns json with a card payment method with no tokenization specification`() {
-        val requestJson = ReadyToPayRequest().toApiV2RequestJson(baseApiV2Request)
+        val requestJson = ReadyToPayRequest(
+            billingAddressRequired = false
+        ).toApiV2RequestJson(baseApiV2Request)
         requestJson.get("allowedPaymentMethods").toString() shouldBeEqualTo JSONArray()
-            .put(CardPaymentMethod().toApiV2RequestJson(tokenizationSpecification = null))
+            .put(
+                CardPaymentMethod().toApiV2RequestJson(
+                    billingAddressRequired = false,
+                    tokenizationSpecification = null
+                )
+            )
+            .toString()
+    }
+
+    @Test
+    fun `toApiV2RequestJson returns json with a card payment method with billing address required when it is`() {
+        val requestJson = ReadyToPayRequest(
+            billingAddressRequired = true
+        ).toApiV2RequestJson(baseApiV2Request)
+        requestJson.get("allowedPaymentMethods").toString() shouldBeEqualTo JSONArray()
+            .put(
+                CardPaymentMethod().toApiV2RequestJson(
+                    billingAddressRequired = true,
+                    tokenizationSpecification = null
+                )
+            )
             .toString()
     }
 
     @Test
     fun `toApiV2RequestJson returns expected json when existingPaymentMethodRequired is not provided`() {
-        val requestJson = ReadyToPayRequest().toApiV2RequestJson(baseApiV2Request)
+        val requestJson = ReadyToPayRequest(
+            billingAddressRequired = false
+        ).toApiV2RequestJson(baseApiV2Request)
         requestJson.get("existingPaymentMethodRequired") shouldBeEqualTo true
     }
 
     @Test
     fun `toApiV2RequestJson returns expected json when existingPaymentMethodRequired is true`() {
         val requestJson = ReadyToPayRequest(
+            billingAddressRequired = false,
             existingPaymentMethodRequired = true
         ).toApiV2RequestJson(baseApiV2Request)
         requestJson.get("existingPaymentMethodRequired") shouldBeEqualTo true
@@ -43,6 +70,7 @@ internal class ReadyToPayRequestTest {
     @Test
     fun `toApiV2RequestJson returns expected json when existingPaymentMethodRequired is false`() {
         val requestJson = ReadyToPayRequest(
+            billingAddressRequired = false,
             existingPaymentMethodRequired = false
         ).toApiV2RequestJson(baseApiV2Request)
         requestJson.get("existingPaymentMethodRequired") shouldBeEqualTo false

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/service/DefaultGooglePayServiceTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/service/DefaultGooglePayServiceTest.kt
@@ -16,8 +16,18 @@ internal class DefaultGooglePayServiceTest {
         ?.readText()
         ?.replace(Regex("\\s+"), "")
 
+    private val isReadyToPayRequestJsonWithBillingAddressRequired = DefaultGooglePayServiceTest::class.java
+        .getResource("/assets/googlepay/is-ready-to-pay-request-billing-address-required.json")
+        ?.readText()
+        ?.replace(Regex("\\s+"), "")
+
     private val paymentDataRequestJson = DefaultGooglePayServiceTest::class.java
         .getResource("/assets/googlepay/payment-data-request.json")
+        ?.readText()
+        ?.replace(Regex("\\s+"), "")
+
+    private val paymentDataRequestJsonWithBillingAddressRequired = DefaultGooglePayServiceTest::class.java
+        .getResource("/assets/googlepay/payment-data-request-billing-address-required.json")
         ?.readText()
         ?.replace(Regex("\\s+"), "")
 
@@ -25,8 +35,8 @@ internal class DefaultGooglePayServiceTest {
     private val service: GooglePayService = DefaultGooglePayService(client)
 
     @Test
-    fun `isReadyToPay uses expected request`() {
-        service.isReadyToPay()
+    fun `isReadyToPay uses expected request when billing address is not required`() {
+        service.isReadyToPay(billingAddressRequired = false)
 
         verify {
             client.isReadyToPay(
@@ -38,11 +48,25 @@ internal class DefaultGooglePayServiceTest {
     }
 
     @Test
-    fun `loadPaymentData uses expected request`() {
+    fun `isReadyToPay uses expected request when billing address is required`() {
+        service.isReadyToPay(billingAddressRequired = true)
+
+        verify {
+            client.isReadyToPay(
+                match {
+                    it.toJson() == isReadyToPayRequestJsonWithBillingAddressRequired
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `loadPaymentData uses expected request when billing address is not required`() {
         service.loadPaymentData(
             mockk(relaxed = true),
             LoadPaymentDataRequest(
                 merchantInfo,
+                billingAddressRequired = false,
                 ryftTokenizationSpecification,
                 transactionInfo
             )
@@ -52,6 +76,27 @@ internal class DefaultGooglePayServiceTest {
             client.loadPaymentData(
                 match {
                     it.toJson() == paymentDataRequestJson
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `loadPaymentData uses expected request when billing address is required`() {
+        service.loadPaymentData(
+            mockk(relaxed = true),
+            LoadPaymentDataRequest(
+                merchantInfo,
+                billingAddressRequired = true,
+                ryftTokenizationSpecification,
+                transactionInfo
+            )
+        )
+
+        verify {
+            client.loadPaymentData(
+                match {
+                    it.toJson() == paymentDataRequestJsonWithBillingAddressRequired
                 }
             )
         }

--- a/ryft-ui/src/test/resources/assets/googlepay/is-ready-to-pay-request-billing-address-required.json
+++ b/ryft-ui/src/test/resources/assets/googlepay/is-ready-to-pay-request-billing-address-required.json
@@ -1,0 +1,18 @@
+{
+  "apiVersionMinor": 0,
+  "apiVersion": 2,
+  "allowedPaymentMethods": [
+    {
+      "type": "CARD",
+      "parameters": {
+        "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+        "billingAddressRequired": true,
+        "billingAddressParameters": {
+          "format": "FULL"
+        },
+        "allowedCardNetworks": ["VISA", "MASTERCARD"]
+      }
+    }
+  ],
+  "existingPaymentMethodRequired": true
+}

--- a/ryft-ui/src/test/resources/assets/googlepay/payment-data-request-billing-address-required.json
+++ b/ryft-ui/src/test/resources/assets/googlepay/payment-data-request-billing-address-required.json
@@ -1,0 +1,35 @@
+{
+  "apiVersionMinor": 0,
+  "apiVersion": 2,
+  "merchantInfo": {
+    "merchantName": "Merchant"
+  },
+  "allowedPaymentMethods": [
+    {
+      "type": "CARD",
+      "parameters": {
+        "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+        "billingAddressRequired": true,
+        "billingAddressParameters": {
+          "format": "FULL"
+        },
+        "allowedCardNetworks": ["VISA", "MASTERCARD"]
+      },
+      "tokenizationSpecification": {
+        "type": "PAYMENT_GATEWAY",
+        "parameters": {
+          "gatewayMerchantId": "pk_sandbox_123",
+          "gateway": "ryft"
+        }
+      }
+    }
+  ],
+  "transactionInfo": {
+    "totalPrice": "4.02",
+    "countryCode": "GB",
+    "checkoutOption": "COMPLETE_IMMEDIATE_PURCHASE",
+    "totalPriceStatus": "FINAL",
+    "currencyCode": "GBP",
+    "transactionId": "ps_123"
+  }
+}

--- a/ryft-ui/src/test/resources/assets/googlepay/payment-data-response-with-full-billing-address.json
+++ b/ryft-ui/src/test/resources/assets/googlepay/payment-data-response-with-full-billing-address.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": 2,
+  "apiVersionMinor": 0,
+  "paymentMethodData": {
+    "type": "CARD",
+    "description": "Visa •••• 1234",
+    "info": {
+      "cardNetwork": "VISA",
+      "cardDetails": "1234",
+      "billingAddress": {
+        "name": "John Doe",
+        "address1": "c/o Google LLC",
+        "address2": "1600 Amphitheatre Pkwy",
+        "address3": "Building 40",
+        "locality": "Mountain View",
+        "administrativeArea": "CA",
+        "countryCode": "US",
+        "postalCode": "94043",
+        "sortingCode": ""
+      }
+    },
+    "tokenizationData": {
+      "type": "PAYMENT_GATEWAY",
+      "token": "examplePaymentMethodToken"
+    }
+  }
+}

--- a/ryft-ui/src/test/resources/assets/googlepay/payment-data-response-with-partial-billing-address.json
+++ b/ryft-ui/src/test/resources/assets/googlepay/payment-data-response-with-partial-billing-address.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": 2,
+  "apiVersionMinor": 0,
+  "paymentMethodData": {
+    "type": "CARD",
+    "description": "Visa •••• 1234",
+    "info": {
+      "cardNetwork": "VISA",
+      "cardDetails": "1234",
+      "billingAddress": {
+        "name": "",
+        "address1": "",
+        "address2": "",
+        "address3": "",
+        "locality": "",
+        "administrativeArea": "",
+        "countryCode": "GB",
+        "postalCode": "SW1A 2AA",
+        "sortingCode": ""
+      }
+    },
+    "tokenizationData": {
+      "type": "PAYMENT_GATEWAY",
+      "token": "examplePaymentMethodToken"
+    }
+  }
+}


### PR DESCRIPTION
- Add optional flag to control whether or not to take billing address details from the customer via Google Pay
- Add new core models to match api
- Configure both Google Pay requests to request the full billing address if it's required
- Extract billing address from Google Pay payment data response if it exists
- Update README