### PR TITLE
[R1281] Google pay optional config

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ class CheckoutFragment : Fragment() {
 }
 ```
 
+#### Google Pay
+
+Google Pay will be available for users providing the following is true:
+- You have provided a RyftDropInGooglePayConfiguration object when displaying the drop-in
+- The user has Google Pay setup on their device
+
+Note: if you don't provide a RyftDropInGooglePayConfiguration object then Google Pay is disabled
+
 ### Implementing the RyftDropInResultListener
 
 Once the customer has submitted their payment, the drop-in will dismiss.

--- a/ryft-ui/src/androidTest/java/com/ryftpay/android/ui/fragment/RyftPaymentFragmentTest.kt
+++ b/ryft-ui/src/androidTest/java/com/ryftpay/android/ui/fragment/RyftPaymentFragmentTest.kt
@@ -35,7 +35,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ryftpay.android.core.model.api.RyftPublicApiKey
 import com.ryftpay.android.ui.component.RyftButton
 import com.ryftpay.android.ui.dropin.RyftDropInConfiguration
-import com.ryftpay.android.ui.dropin.RyftDropInGooglePayConfiguration
 import com.ryftpay.ui.R
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
@@ -617,11 +616,7 @@ internal class RyftPaymentFragmentTest {
     private fun createFragmentArgs(): Bundle {
         val configuration = RyftDropInConfiguration(
             clientSecret = "secret_123",
-            subAccountId = null,
-            googlePayConfiguration = RyftDropInGooglePayConfiguration(
-                merchantName = "Ryft",
-                merchantCountryCode = "GB"
-            )
+            subAccountId = null
         )
         val publicApiKey = RyftPublicApiKey("pk_sandbox_123")
         return bundleOf(

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInConfiguration.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInConfiguration.kt
@@ -1,11 +1,15 @@
 package com.ryftpay.android.ui.dropin
 
 import android.os.Parcelable
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class RyftDropInConfiguration(
     val clientSecret: String,
     val subAccountId: String?,
-    val googlePayConfiguration: RyftDropInGooglePayConfiguration
-) : Parcelable
+    val googlePayConfiguration: RyftDropInGooglePayConfiguration? = null
+) : Parcelable {
+    @IgnoredOnParcel
+    internal val googlePayEnabled = googlePayConfiguration != null
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfiguration.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfiguration.kt
@@ -1,10 +1,14 @@
 package com.ryftpay.android.ui.dropin
 
 import android.os.Parcelable
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class RyftDropInGooglePayConfiguration(
     val merchantName: String,
     val merchantCountryCode: String
-) : Parcelable
+) : Parcelable {
+    @IgnoredOnParcel
+    internal val billingAddressRequired = true
+}

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/TestData.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/TestData.kt
@@ -29,6 +29,7 @@ internal object TestData {
     private const val VALID_AMEX_RAW_CVC = "5432"
     private const val INVALID_AMEX_RAW_CVC = "54321"
 
+    internal const val CLIENT_SECRET = "ps_123_secret_456"
     internal const val MERCHANT_NAME = "Merchant"
     internal const val GB_COUNTRY_CODE = "GB"
 

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/RyftDropInConfigurationTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/RyftDropInConfigurationTest.kt
@@ -1,0 +1,39 @@
+package com.ryftpay.android.ui.dropin
+
+import com.ryftpay.android.ui.TestData.CLIENT_SECRET
+import com.ryftpay.android.ui.TestData.GB_COUNTRY_CODE
+import com.ryftpay.android.ui.TestData.MERCHANT_NAME
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+internal class RyftDropInConfigurationTest {
+
+    @Test
+    internal fun `googlePayConfiguration should be null when not provided`() {
+        RyftDropInConfiguration(
+            clientSecret = CLIENT_SECRET,
+            subAccountId = null
+        ).googlePayConfiguration shouldBeEqualTo null
+    }
+
+    @Test
+    internal fun `googlePayEnabled should return true when google pay configuration is not null`() {
+        RyftDropInConfiguration(
+            clientSecret = CLIENT_SECRET,
+            subAccountId = null,
+            googlePayConfiguration = RyftDropInGooglePayConfiguration(
+                merchantName = MERCHANT_NAME,
+                merchantCountryCode = GB_COUNTRY_CODE
+            )
+        ).googlePayEnabled shouldBeEqualTo true
+    }
+
+    @Test
+    internal fun `googlePayEnabled should return false when google pay configuration is null`() {
+        RyftDropInConfiguration(
+            clientSecret = CLIENT_SECRET,
+            subAccountId = null,
+            googlePayConfiguration = null
+        ).googlePayEnabled shouldBeEqualTo false
+    }
+}

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfigurationTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfigurationTest.kt
@@ -1,0 +1,17 @@
+package com.ryftpay.android.ui.dropin
+
+import com.ryftpay.android.ui.TestData.GB_COUNTRY_CODE
+import com.ryftpay.android.ui.TestData.MERCHANT_NAME
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+internal class RyftDropInGooglePayConfigurationTest {
+
+    @Test
+    internal fun `billingAddressRequired should be true`() {
+        RyftDropInGooglePayConfiguration(
+            merchantName = MERCHANT_NAME,
+            merchantCountryCode = GB_COUNTRY_CODE
+        ).billingAddressRequired shouldBeEqualTo true
+    }
+}


### PR DESCRIPTION
- Make the drop in configuration for google pay optional & disable google pay when it is not provided
- Update README to clarify enabling/disabling google pay
- Move flag controlling whether the google pay billing address is required from the fragment to the drop in config (still un-configurable and hard-coded to true)