### PR TITLE
[R1319] Google pay - existing payment methods

### DIFF
--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfiguration.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfiguration.kt
@@ -10,5 +10,7 @@ data class RyftDropInGooglePayConfiguration(
     val merchantCountryCode: String
 ) : Parcelable {
     @IgnoredOnParcel
+    internal val existingPaymentMethodRequired = false
+    @IgnoredOnParcel
     internal val billingAddressRequired = true
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/fragment/RyftPaymentFragment.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/fragment/RyftPaymentFragment.kt
@@ -274,6 +274,7 @@ internal class RyftPaymentFragment :
     private fun checkGooglePayIsAvailableBeforeInitialisingDelegate(root: View) {
         val googlePayConfiguration = input.configuration.googlePayConfiguration ?: return
         googlePayService!!.isReadyToPay(
+            googlePayConfiguration.existingPaymentMethodRequired,
             googlePayConfiguration.billingAddressRequired
         ).addOnCompleteListener { completedTask ->
             run {

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/ReadyToPayRequest.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/model/googlepay/ReadyToPayRequest.kt
@@ -4,7 +4,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 internal data class ReadyToPayRequest(
-    val existingPaymentMethodRequired: Boolean = true,
+    val existingPaymentMethodRequired: Boolean,
     val billingAddressRequired: Boolean
 ) {
     internal fun toApiV2RequestJson(
@@ -12,7 +12,9 @@ internal data class ReadyToPayRequest(
     ): JSONObject = JSONObject(
         baseApiRequest.toApiRequestJson().toString()
     ).apply {
-        put(EXISTING_PAYMENT_METHOD_REQUIRED_KEY, existingPaymentMethodRequired)
+        if (existingPaymentMethodRequired) {
+            put(EXISTING_PAYMENT_METHOD_REQUIRED_KEY, true)
+        }
         put(
             PaymentMethod.ALLOWED_PAYMENT_METHODS_KEY,
             JSONArray()

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/service/DefaultGooglePayService.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/service/DefaultGooglePayService.kt
@@ -20,10 +20,12 @@ internal class DefaultGooglePayService(
     )
 
     override fun isReadyToPay(
+        existingPaymentMethodRequired: Boolean,
         billingAddressRequired: Boolean
     ): Task<Boolean> = paymentsClient.isReadyToPay(
         IsReadyToPayRequest.fromJson(
             ReadyToPayRequest(
+                existingPaymentMethodRequired = existingPaymentMethodRequired,
                 billingAddressRequired = billingAddressRequired
             ).toApiV2RequestJson(baseApiV2Request).toString()
         )

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/service/GooglePayService.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/service/GooglePayService.kt
@@ -6,8 +6,10 @@ import com.ryftpay.android.ui.model.googlepay.LoadPaymentDataRequest
 
 internal interface GooglePayService {
     fun isReadyToPay(
+        existingPaymentMethodRequired: Boolean,
         billingAddressRequired: Boolean
     ): Task<Boolean>
+
     fun loadPaymentData(
         activity: Activity,
         loadPaymentDataRequest: LoadPaymentDataRequest

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfigurationTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/RyftDropInGooglePayConfigurationTest.kt
@@ -8,6 +8,14 @@ import org.junit.Test
 internal class RyftDropInGooglePayConfigurationTest {
 
     @Test
+    internal fun `existingPaymentMethodRequired should be false`() {
+        RyftDropInGooglePayConfiguration(
+            merchantName = MERCHANT_NAME,
+            merchantCountryCode = GB_COUNTRY_CODE
+        ).existingPaymentMethodRequired shouldBeEqualTo false
+    }
+
+    @Test
     internal fun `billingAddressRequired should be true`() {
         RyftDropInGooglePayConfiguration(
             merchantName = MERCHANT_NAME,

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/model/googlepay/ReadyToPayRequestTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/model/googlepay/ReadyToPayRequestTest.kt
@@ -14,15 +14,17 @@ internal class ReadyToPayRequestTest {
     @Test
     fun `toApiV2RequestJson returns json with api versions`() {
         val requestJson = ReadyToPayRequest(
+            existingPaymentMethodRequired = false,
             billingAddressRequired = false
         ).toApiV2RequestJson(baseApiV2Request)
-        requestJson.get("apiVersion") shouldBeEqualTo 2
-        requestJson.get("apiVersionMinor") shouldBeEqualTo 0
+        requestJson.getInt("apiVersion") shouldBeEqualTo 2
+        requestJson.getInt("apiVersionMinor") shouldBeEqualTo 0
     }
 
     @Test
     fun `toApiV2RequestJson returns json with a card payment method with no tokenization specification`() {
         val requestJson = ReadyToPayRequest(
+            existingPaymentMethodRequired = false,
             billingAddressRequired = false
         ).toApiV2RequestJson(baseApiV2Request)
         requestJson.get("allowedPaymentMethods").toString() shouldBeEqualTo JSONArray()
@@ -38,6 +40,7 @@ internal class ReadyToPayRequestTest {
     @Test
     fun `toApiV2RequestJson returns json with a card payment method with billing address required when it is`() {
         val requestJson = ReadyToPayRequest(
+            existingPaymentMethodRequired = false,
             billingAddressRequired = true
         ).toApiV2RequestJson(baseApiV2Request)
         requestJson.get("allowedPaymentMethods").toString() shouldBeEqualTo JSONArray()
@@ -51,28 +54,20 @@ internal class ReadyToPayRequestTest {
     }
 
     @Test
-    fun `toApiV2RequestJson returns expected json when existingPaymentMethodRequired is not provided`() {
-        val requestJson = ReadyToPayRequest(
-            billingAddressRequired = false
-        ).toApiV2RequestJson(baseApiV2Request)
-        requestJson.get("existingPaymentMethodRequired") shouldBeEqualTo true
-    }
-
-    @Test
-    fun `toApiV2RequestJson returns expected json when existingPaymentMethodRequired is true`() {
+    fun `toApiV2RequestJson returns json with existingPaymentMethodRequired when it is true`() {
         val requestJson = ReadyToPayRequest(
             billingAddressRequired = false,
             existingPaymentMethodRequired = true
         ).toApiV2RequestJson(baseApiV2Request)
-        requestJson.get("existingPaymentMethodRequired") shouldBeEqualTo true
+        requestJson.getBoolean("existingPaymentMethodRequired") shouldBeEqualTo true
     }
 
     @Test
-    fun `toApiV2RequestJson returns expected json when existingPaymentMethodRequired is false`() {
+    fun `toApiV2RequestJson returns json without existingPaymentMethodRequired when it is false`() {
         val requestJson = ReadyToPayRequest(
             billingAddressRequired = false,
             existingPaymentMethodRequired = false
         ).toApiV2RequestJson(baseApiV2Request)
-        requestJson.get("existingPaymentMethodRequired") shouldBeEqualTo false
+        requestJson.optBoolean("existingPaymentMethodRequired") shouldBeEqualTo false
     }
 }

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/service/DefaultGooglePayServiceTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/service/DefaultGooglePayServiceTest.kt
@@ -16,6 +16,11 @@ internal class DefaultGooglePayServiceTest {
         ?.readText()
         ?.replace(Regex("\\s+"), "")
 
+    private val isReadyToPayRequestJsonWithExistingPaymentMethodRequired = DefaultGooglePayServiceTest::class.java
+        .getResource("/assets/googlepay/is-ready-to-pay-request-existing-payment-method-required.json")
+        ?.readText()
+        ?.replace(Regex("\\s+"), "")
+
     private val isReadyToPayRequestJsonWithBillingAddressRequired = DefaultGooglePayServiceTest::class.java
         .getResource("/assets/googlepay/is-ready-to-pay-request-billing-address-required.json")
         ?.readText()
@@ -40,8 +45,11 @@ internal class DefaultGooglePayServiceTest {
     private val service: GooglePayService = DefaultGooglePayService(client)
 
     @Test
-    fun `isReadyToPay uses expected request when billing address is not required`() {
-        service.isReadyToPay(billingAddressRequired = false)
+    fun `isReadyToPay uses expected request when billing address and existing payment method are not required`() {
+        service.isReadyToPay(
+            existingPaymentMethodRequired = false,
+            billingAddressRequired = false
+        )
 
         verify {
             client.isReadyToPay(
@@ -53,8 +61,27 @@ internal class DefaultGooglePayServiceTest {
     }
 
     @Test
+    fun `isReadyToPay uses expected request when existing payment method is required`() {
+        service.isReadyToPay(
+            existingPaymentMethodRequired = true,
+            billingAddressRequired = false
+        )
+
+        verify {
+            client.isReadyToPay(
+                match {
+                    it.toJson() == isReadyToPayRequestJsonWithExistingPaymentMethodRequired
+                }
+            )
+        }
+    }
+
+    @Test
     fun `isReadyToPay uses expected request when billing address is required`() {
-        service.isReadyToPay(billingAddressRequired = true)
+        service.isReadyToPay(
+            existingPaymentMethodRequired = false,
+            billingAddressRequired = true
+        )
 
         verify {
             client.isReadyToPay(

--- a/ryft-ui/src/test/resources/assets/googlepay/is-ready-to-pay-request-billing-address-required.json
+++ b/ryft-ui/src/test/resources/assets/googlepay/is-ready-to-pay-request-billing-address-required.json
@@ -13,6 +13,5 @@
         "allowedCardNetworks": ["VISA", "MASTERCARD"]
       }
     }
-  ],
-  "existingPaymentMethodRequired": true
+  ]
 }

--- a/ryft-ui/src/test/resources/assets/googlepay/is-ready-to-pay-request-existing-payment-method-required.json
+++ b/ryft-ui/src/test/resources/assets/googlepay/is-ready-to-pay-request-existing-payment-method-required.json
@@ -9,5 +9,6 @@
         "allowedCardNetworks": ["VISA", "MASTERCARD"]
       }
     }
-  ]
+  ],
+  "existingPaymentMethodRequired": true
 }


### PR DESCRIPTION
- Move the 'existingPaymentMethodRequired' flag to be specified in RyftDropInGooglePayConfiguration for consistency with the 'billingAddressRequired' flag
- Update default value of 'existingPaymentMethodRequired' flag to false for consistency with our web SDK