### PR TITLE
[R1332] Setup card

### DIFF
--- a/ryft-ui/src/androidTest/java/com/ryftpay/android/ui/fragment/RyftPaymentFragmentTest.kt
+++ b/ryft-ui/src/androidTest/java/com/ryftpay/android/ui/fragment/RyftPaymentFragmentTest.kt
@@ -37,6 +37,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ryftpay.android.core.model.api.RyftPublicApiKey
 import com.ryftpay.android.ui.component.RyftButton
 import com.ryftpay.android.ui.dropin.RyftDropInConfiguration
+import com.ryftpay.android.ui.dropin.RyftDropInDisplayConfiguration
+import com.ryftpay.android.ui.dropin.RyftDropInUsage
 import com.ryftpay.ui.R
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.not
@@ -47,8 +49,8 @@ import org.junit.runner.RunWith
 internal class RyftPaymentFragmentTest {
 
     @Test
-    internal fun shouldShowExpectedData_OnLaunch() {
-        launchFragment()
+    internal fun shouldShowExpectedData_OnLaunch_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         onView(
             withId(R.id.text_ryft_payment_form_card_only_header)
@@ -95,6 +97,16 @@ internal class RyftPaymentFragmentTest {
 
         onView(
             allOf(
+                withId(R.id.text_ryft_save_card_disclaimer)
+            )
+        ).check(
+            matches(
+                not(isDisplayed())
+            )
+        )
+
+        onView(
+            allOf(
                 withId(R.id.text_ryft_button),
                 isDescendantOfA(withId(R.id.button_ryft_pay))
             )
@@ -117,8 +129,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldEnableCancelAndInputFields_OnLaunch() {
-        launchFragment()
+    internal fun shouldEnableCancelAndInputFields_OnLaunch_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         onView(
             withId(R.id.button_ryft_pay)
@@ -178,8 +190,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldHaveExpectedLayout_OnLaunch() {
-        launchFragment()
+    internal fun shouldHaveExpectedLayout_OnLaunch_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         assertNoLayoutBreakages()
 
@@ -239,8 +251,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldFocusOnFieldsAsExpected_OnLaunchAndAfterTypingText() {
-        launchFragment()
+    internal fun shouldFocusOnFieldsAsExpected_OnLaunchAndAfterTypingText_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         onView(
             withId(R.id.input_field_ryft_card_number)
@@ -286,8 +298,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldFormatFieldsAsExpected_AfterTypingText() {
-        launchFragment()
+    internal fun shouldFormatFieldsAsExpected_AfterTypingText_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         onView(
             withId(R.id.input_field_ryft_card_number)
@@ -367,8 +379,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldNotAllowInvalidCharacters_WhenTypingText() {
-        launchFragment()
+    internal fun shouldNotAllowInvalidCharacters_WhenTypingText_AndDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         onView(
             withId(R.id.input_field_ryft_card_number)
@@ -414,8 +426,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldRestrictTheMaxLengthOfTheField_WhenTypingText() {
-        launchFragment()
+    internal fun shouldRestrictTheMaxLengthOfTheField_WhenTypingText_AndDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         onView(
             withId(R.id.input_field_ryft_card_number)
@@ -461,8 +473,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldNotTruncateCvc_WhenCardTypeIsAmex() {
-        launchFragment()
+    internal fun shouldNotTruncateCvc_WhenCardTypeIsAmex_AndDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         onView(
             withId(R.id.input_field_ryft_card_cvc)
@@ -502,8 +514,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldEnablePay_AfterInputtingValidCardDetails() {
-        launchFragment()
+    internal fun shouldEnablePay_AfterInputtingValidCardDetails_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         inputValidCardDetails()
 
@@ -513,8 +525,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldChangePayButtonText_AfterClickingPay() {
-        launchFragment()
+    internal fun shouldChangePayButtonText_AfterClickingPay_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         inputValidCardDetails()
 
@@ -527,14 +539,14 @@ internal class RyftPaymentFragmentTest {
             )
         ).check(
             matches(
-                allOf(isDisplayed(), withText("Taking payment…"))
+                allOf(isDisplayed(), withText("Processing…"))
             )
         )
     }
 
     @Test
-    internal fun shouldSetCheckBox_AfterCheckBoxIsClicked() {
-        launchFragment()
+    internal fun shouldSetCheckBox_AfterCheckBoxIsClicked_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         onView(withId(R.id.chk_ryft_internal)).perform(click())
 
@@ -551,8 +563,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldSetCheckBox_AfterCheckBoxTextIsClicked() {
-        launchFragment()
+    internal fun shouldSetCheckBox_AfterCheckBoxTextIsClicked_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         onView(withId(R.id.text_ryft_check_box)).perform(click())
 
@@ -569,8 +581,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldDisablePayAndCancelAndInputFields_AfterClickingPay() {
-        launchFragment()
+    internal fun shouldDisablePayAndCancelAndInputFields_AfterClickingPay_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         inputValidCardDetails()
 
@@ -618,8 +630,8 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldHaveExpectedLayout_AfterClickingPay() {
-        launchFragment()
+    internal fun shouldHaveExpectedLayout_AfterClickingPay_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
 
         inputValidCardDetails()
 
@@ -641,8 +653,571 @@ internal class RyftPaymentFragmentTest {
     }
 
     @Test
-    internal fun shouldBeDismissed_AfterClickingCancel() {
-        launchFragment()
+    internal fun shouldBeDismissed_AfterClickingCancel_WhenDropInUsedForPayments() {
+        launchFragment(RyftDropInUsage.Payment)
+
+        onView(isRoot()).check(matches(hasDescendant(withId(R.id.fragment_ryft_payment))))
+
+        onView(withId(R.id.button_ryft_cancel)).perform(click())
+
+        onView(isRoot()).check(matches(not(hasDescendant(withId(R.id.fragment_ryft_payment)))))
+    }
+
+    @Test
+    internal fun shouldShowExpectedData_OnLaunch_WhenDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        onView(
+            withId(R.id.text_ryft_payment_form_card_only_header)
+        ).check(
+            matches(
+                allOf(isDisplayed(), withText("Authorise Card"))
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_number)
+        ).check(
+            matches(
+                allOf(isDisplayed(), withHint("Card number"))
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_expiry_date)
+        ).check(
+            matches(
+                allOf(isDisplayed(), withHint("MM/YY"))
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_cvc)
+        ).check(
+            matches(
+                allOf(isDisplayed(), withHint("CVC"))
+            )
+        )
+
+        onView(
+            allOf(
+                withId(R.id.text_ryft_save_card_disclaimer)
+            )
+        ).check(
+            matches(
+                allOf(isDisplayed(), withText("By authorising your card, you consent to your details being stored securely for future payments"))
+            )
+        )
+
+        onView(
+            allOf(
+                withId(R.id.text_ryft_check_box),
+                isDescendantOfA(withId(R.id.check_box_ryft_save_card))
+            )
+        ).check(
+            matches(
+                not(isDisplayed())
+            )
+        )
+
+        onView(
+            allOf(
+                withId(R.id.text_ryft_button),
+                isDescendantOfA(withId(R.id.button_ryft_pay))
+            )
+        ).check(
+            matches(
+                allOf(isDisplayed(), withText("Save card"))
+            )
+        )
+
+        onView(
+            allOf(
+                withId(R.id.text_ryft_button),
+                isDescendantOfA(withId(R.id.button_ryft_cancel))
+            )
+        ).check(
+            matches(
+                allOf(isDisplayed(), withText("Cancel"))
+            )
+        )
+    }
+
+    @Test
+    internal fun shouldEnableCancelAndInputFields_OnLaunch_WhenDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        onView(
+            withId(R.id.button_ryft_pay)
+        ).check(
+            matches(
+                allOf(not(isEnabled()), not(isClickable()))
+            )
+        )
+
+        onView(
+            withId(R.id.button_ryft_cancel)
+        ).check(
+            matches(
+                allOf(isEnabled(), isClickable())
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_number)
+        ).check(
+            matches(
+                allOf(isEnabled(), isFocused())
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_expiry_date)
+        ).check(
+            matches(
+                allOf(isEnabled(), isFocusable())
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_cvc)
+        ).check(
+            matches(
+                allOf(isEnabled(), isFocusable())
+            )
+        )
+    }
+
+    @Test
+    internal fun shouldHaveExpectedLayout_OnLaunch_WhenDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        assertNoLayoutBreakages()
+
+        onView(
+            withId(R.id.text_ryft_payment_form_card_only_header)
+        ).check(
+            isCompletelyAbove(
+                withId(R.id.partial_ryft_payment_form_body)
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_number)
+        ).check(
+            isCompletelyAbove(
+                withId(R.id.input_field_ryft_card_expiry_date)
+            )
+        ).check(
+            isCompletelyAbove(
+                withId(R.id.input_field_ryft_card_cvc)
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_expiry_date)
+        ).check(
+            isCompletelyLeftOf(
+                withId(R.id.input_field_ryft_card_cvc)
+            )
+        ).check(
+            isCompletelyAbove(
+                withId(R.id.text_ryft_save_card_disclaimer)
+            )
+        )
+
+        onView(
+            withId(R.id.text_ryft_save_card_disclaimer)
+        ).check(
+            isCompletelyAbove(
+                withId(R.id.partial_ryft_payment_form_footer)
+            )
+        )
+
+        onView(
+            withId(R.id.button_ryft_pay)
+        ).check(
+            matches(isDisplayed())
+        ).check(
+            isCompletelyLeftOf(withId(R.id.button_ryft_cancel))
+        )
+
+        onView(
+            withId(R.id.button_ryft_cancel)
+        ).check(
+            matches(isDisplayed())
+        )
+    }
+
+    @Test
+    internal fun shouldFocusOnFieldsAsExpected_OnLaunchAndAfterTypingText_WhenDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        onView(
+            withId(R.id.input_field_ryft_card_number)
+        ).check(
+            matches(
+                isFocused()
+            )
+        ).perform(
+            typeTextIntoFocusedView("4242424242424242")
+        ).check(
+            matches(
+                isNotFocused()
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_expiry_date)
+        ).check(
+            matches(
+                isFocused()
+            )
+        ).perform(
+            typeTextIntoFocusedView("1225"),
+        ).check(
+            matches(
+                isNotFocused()
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_cvc)
+        ).check(
+            matches(
+                isFocused()
+            )
+        ).perform(
+            typeTextIntoFocusedView("123"),
+        ).check(
+            matches(
+                isNotFocused()
+            )
+        )
+    }
+
+    @Test
+    internal fun shouldFormatFieldsAsExpected_AfterTypingText_WhenDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        onView(
+            withId(R.id.input_field_ryft_card_number)
+        ).perform(
+            typeText("4242")
+        ).check(
+            matches(
+                withText("4242 ")
+            )
+        ).perform(
+            typeText("424242424241")
+        ).check(
+            matches(
+                withText("4242 4242 4242 4241")
+            )
+        ).perform(
+            pressKey(KeyEvent.KEYCODE_DEL),
+            pressKey(KeyEvent.KEYCODE_DEL),
+            pressKey(KeyEvent.KEYCODE_DEL),
+            pressKey(KeyEvent.KEYCODE_DEL)
+        ).check(
+            matches(
+                withText("4242 4242 4242")
+            )
+        ).perform(
+            typeText("4242")
+        ).check(
+            matches(
+                withText("4242 4242 4242 4242")
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_expiry_date)
+        ).perform(
+            typeText("12")
+        ).check(
+            matches(
+                withText("12/")
+            )
+        ).perform(
+            typeText("12")
+        ).check(
+            matches(
+                withText("12/12")
+            )
+        ).perform(
+            pressKey(KeyEvent.KEYCODE_DEL),
+            pressKey(KeyEvent.KEYCODE_DEL)
+        ).check(
+            matches(
+                withText("12")
+            )
+        ).perform(
+            typeText("26")
+        ).check(
+            matches(
+                withText("12/26")
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_cvc)
+        ).perform(
+            typeText("12")
+        ).check(
+            matches(
+                withText("12")
+            )
+        ).perform(
+            typeText("3")
+        ).check(
+            matches(
+                withText("123")
+            )
+        )
+    }
+
+    @Test
+    internal fun shouldNotAllowInvalidCharacters_WhenTypingText_AndDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        onView(
+            withId(R.id.input_field_ryft_card_number)
+        ).check(
+            matches(
+                withText("")
+            )
+        ).perform(
+            typeText(CARD_NUMBER_INVALID_CHARACTERS)
+        ).check(
+            matches(
+                withText("")
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_expiry_date)
+        ).check(
+            matches(
+                withText("")
+            )
+        ).perform(
+            typeText(CARD_EXPIRY_DATE_INVALID_CHARACTERS)
+        ).check(
+            matches(
+                withText("")
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_cvc)
+        ).check(
+            matches(
+                withText("")
+            )
+        ).perform(
+            typeText(CARD_CVC_INVALID_CHARACTERS)
+        ).check(
+            matches(
+                withText("")
+            )
+        )
+    }
+
+    @Test
+    internal fun shouldRestrictTheMaxLengthOfTheField_WhenTypingText_AndDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        onView(
+            withId(R.id.input_field_ryft_card_number)
+        ).check(
+            matches(
+                withText("")
+            )
+        ).perform(
+            typeText("4242424242424241999")
+        ).check(
+            matches(
+                withText("4242 4242 4242 4241")
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_expiry_date)
+        ).check(
+            matches(
+                withText("")
+            )
+        ).perform(
+            typeText("12023456789")
+        ).check(
+            matches(
+                withText("12/02")
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_cvc)
+        ).check(
+            matches(
+                withText("")
+            )
+        ).perform(
+            typeText("1234567890"),
+        ).check(
+            matches(
+                withText("123")
+            )
+        )
+    }
+
+    @Test
+    internal fun shouldNotTruncateCvc_WhenCardTypeIsAmex_AndDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        onView(
+            withId(R.id.input_field_ryft_card_cvc)
+        ).check(
+            matches(
+                withText("")
+            )
+        ).perform(
+            typeText("7373"),
+        ).check(
+            matches(
+                withText("7373")
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_number)
+        ).check(
+            matches(
+                withText("")
+            )
+        ).perform(
+            typeText("370000000000002")
+        ).check(
+            matches(
+                withText("3700 000000 00002")
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_cvc)
+        ).check(
+            matches(
+                withText("7373")
+            )
+        )
+    }
+
+    @Test
+    internal fun shouldEnablePay_AfterInputtingValidCardDetails_WhenDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        inputValidCardDetails()
+
+        onView(withId(R.id.button_ryft_pay)).check(
+            matches(allOf(isEnabled(), isClickable()))
+        )
+    }
+
+    @Test
+    internal fun shouldChangePayButtonText_AfterClickingPay_WhenDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        inputValidCardDetails()
+
+        onView(withId(R.id.button_ryft_pay)).perform(click())
+
+        onView(
+            allOf(
+                withId(R.id.text_ryft_button),
+                isDescendantOfA(withId(R.id.button_ryft_pay))
+            )
+        ).check(
+            matches(
+                allOf(isDisplayed(), withText("Processing…"))
+            )
+        )
+    }
+
+    @Test
+    internal fun shouldDisablePayAndCancelAndInputFields_AfterClickingPay_WhenDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        inputValidCardDetails()
+
+        onView(withId(R.id.button_ryft_pay)).perform(click())
+
+        onView(
+            withId(R.id.button_ryft_pay)
+        ).check(
+            matches(
+                allOf(not(isEnabled()), not(isClickable()))
+            )
+        )
+
+        onView(
+            withId(R.id.button_ryft_cancel)
+        ).check(
+            matches(
+                allOf(not(isEnabled()), not(isClickable()))
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_number)
+        ).check(
+            matches(
+                allOf(not(isEnabled()))
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_expiry_date)
+        ).check(
+            matches(
+                allOf(not(isEnabled()))
+            )
+        )
+
+        onView(
+            withId(R.id.input_field_ryft_card_cvc)
+        ).check(
+            matches(
+                allOf(not(isEnabled()))
+            )
+        )
+    }
+
+    @Test
+    internal fun shouldHaveExpectedLayout_AfterClickingPay_WhenDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
+
+        inputValidCardDetails()
+
+        onView(withId(R.id.button_ryft_pay)).perform(click())
+
+        assertNoLayoutBreakages()
+
+        onView(
+            withId(R.id.button_ryft_pay)
+        ).check(
+            matches(isDisplayed())
+        )
+
+        onView(
+            withId(R.id.button_ryft_cancel)
+        ).check(
+            matches(not(isDisplayed()))
+        )
+    }
+
+    @Test
+    internal fun shouldBeDismissed_AfterClickingCancel_WhenDropInUsedForSetupCard() {
+        launchFragment(RyftDropInUsage.SetupCard)
 
         onView(isRoot()).check(matches(hasDescendant(withId(R.id.fragment_ryft_payment))))
 
@@ -671,10 +1246,10 @@ internal class RyftPaymentFragmentTest {
         )
     }
 
-    private fun launchFragment() {
+    private fun launchFragment(usage: RyftDropInUsage) {
         val navController = TestNavHostController(ApplicationProvider.getApplicationContext())
 
-        launchFragmentInContainer(createFragmentArgs()) {
+        launchFragmentInContainer(createFragmentArgs(usage)) {
             RyftPaymentFragment().also { fragment ->
                 fragment.viewLifecycleOwnerLiveData.observeForever { viewLifecycleOwner ->
                     if (viewLifecycleOwner != null) {
@@ -685,10 +1260,13 @@ internal class RyftPaymentFragmentTest {
         }
     }
 
-    private fun createFragmentArgs(): Bundle {
+    private fun createFragmentArgs(usage: RyftDropInUsage): Bundle {
         val configuration = RyftDropInConfiguration(
             clientSecret = "secret_123",
-            subAccountId = null
+            subAccountId = null,
+            display = RyftDropInDisplayConfiguration(
+                usage
+            )
         )
         val publicApiKey = RyftPublicApiKey("pk_sandbox_123")
         return bundleOf(

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/component/RyftButton.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/component/RyftButton.kt
@@ -2,8 +2,10 @@ package com.ryftpay.android.ui.component
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
 import android.widget.RelativeLayout
 import android.widget.TextView
+import com.ryftpay.android.ui.extension.setOnSingleClickListener
 import com.ryftpay.ui.R
 
 internal class RyftButton @JvmOverloads constructor(
@@ -12,13 +14,35 @@ internal class RyftButton @JvmOverloads constructor(
 ) : RelativeLayout(context, attrs) {
 
     private lateinit var title: TextView
+    private val defaultOpacity = 1F
+    private var opacityWhenDisabled: Float = defaultOpacity
+    private var hideWhenDisabled: Boolean = false
 
-    internal fun initialise(text: String) {
-        title = findViewById(R.id.text_ryft_button)
+    internal fun initialise(
+        text: String,
+        enabled: Boolean,
+        clickListener: (View) -> Unit,
+        opacityWhenDisabled: Float = 1F,
+        hideWhenDisabled: Boolean = false
+    ) {
+        this.title = findViewById(R.id.text_ryft_button)
+        this.opacityWhenDisabled = opacityWhenDisabled
+        this.hideWhenDisabled = hideWhenDisabled
+        setOnSingleClickListener(clickListener)
         setText(text)
+        update(enabled)
     }
 
     internal fun setText(text: String) {
         title.text = text
+    }
+
+    internal fun update(enabled: Boolean) {
+        isEnabled = enabled
+        isClickable = enabled
+        if (hideWhenDisabled) {
+            visibility = if (enabled) View.VISIBLE else View.GONE
+        }
+        alpha = if (enabled) defaultOpacity else opacityWhenDisabled
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/component/RyftPaymentFormBody.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/component/RyftPaymentFormBody.kt
@@ -5,6 +5,8 @@ import android.text.InputFilter
 import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
+import android.widget.TextView
+import com.ryftpay.android.ui.dropin.RyftDropInUsage
 import com.ryftpay.android.ui.extension.addOrReplaceFilter
 import com.ryftpay.android.ui.listener.RyftCardCvcInputListener
 import com.ryftpay.android.ui.listener.RyftCardExpiryDateInputListener
@@ -36,10 +38,11 @@ internal class RyftPaymentFormBody @JvmOverloads constructor(
     private lateinit var cardExpiryDateField: RyftCardExpiryDateInputField
     private lateinit var cardCvcField: RyftCardCvcInputField
     private lateinit var saveCardCheckBox: RyftCheckBox
+    private lateinit var saveCardDisclaimer: TextView
     private lateinit var listener: RyftPaymentFormBodyListener
 
     internal fun initialise(
-        showSaveCardCheckBox: Boolean,
+        usage: RyftDropInUsage,
         listener: RyftPaymentFormBodyListener
     ) {
         this.listener = listener
@@ -58,10 +61,12 @@ internal class RyftPaymentFormBody @JvmOverloads constructor(
         )
         saveCardCheckBox = findViewById(R.id.check_box_ryft_save_card)
         saveCardCheckBox.initialise(
-            text = context.getString(R.string.ryft_save_card),
+            text = context.getString(R.string.ryft_save_card_check_box),
             listener = this
         )
-        saveCardCheckBox.visibility = if (showSaveCardCheckBox) View.VISIBLE else View.GONE
+        saveCardCheckBox.visibility = if (usage == RyftDropInUsage.Payment) View.VISIBLE else View.GONE
+        saveCardDisclaimer = findViewById(R.id.text_ryft_save_card_disclaimer)
+        saveCardDisclaimer.visibility = if (usage == RyftDropInUsage.SetupCard) View.VISIBLE else View.GONE
 
         cardNumberField.requestFocus()
         toggleInput(enabled = true)

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/component/RyftPaymentFormCardOnlyHeader.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/component/RyftPaymentFormCardOnlyHeader.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.ryftpay.android.ui.dropin.RyftDropInUsage
 import com.ryftpay.ui.R
 
 internal class RyftPaymentFormCardOnlyHeader @JvmOverloads constructor(
@@ -13,8 +14,11 @@ internal class RyftPaymentFormCardOnlyHeader @JvmOverloads constructor(
 
     private lateinit var title: TextView
 
-    internal fun initialise() {
+    internal fun initialise(usage: RyftDropInUsage) {
         title = findViewById(R.id.text_ryft_payment_form_card_only_header)
-        title.text = context.getString(R.string.ryft_payment_form_card_only_header_title)
+        title.text = when (usage) {
+            RyftDropInUsage.Payment -> context.getString(R.string.ryft_payment_form_card_only_header_title)
+            RyftDropInUsage.SetupCard -> context.getString(R.string.ryft_save_card_form_title)
+        }
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/component/RyftPaymentFormFooter.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/component/RyftPaymentFormFooter.kt
@@ -2,9 +2,8 @@ package com.ryftpay.android.ui.component
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
 import android.widget.LinearLayout
-import com.ryftpay.android.ui.extension.setOnSingleClickListener
+import com.ryftpay.android.ui.dropin.RyftDropInUsage
 import com.ryftpay.android.ui.listener.RyftPaymentFormFooterListener
 import com.ryftpay.ui.R
 
@@ -15,81 +14,89 @@ internal class RyftPaymentFormFooter @JvmOverloads constructor(
 
     private lateinit var payButton: RyftButton
     private lateinit var cancelButton: RyftButton
-    private lateinit var state: State
+    private lateinit var usage: RyftDropInUsage
+    private var state: State = State.AwaitingCardDetails
+    private var payButtonTitleOverride: String? = null
 
-    internal fun initialise(listener: RyftPaymentFormFooterListener) {
-        payButton = findViewById(R.id.button_ryft_pay)
-        cancelButton = findViewById(R.id.button_ryft_cancel)
+    internal fun initialise(
+        usage: RyftDropInUsage,
+        payButtonTitleOverride: String?,
+        listener: RyftPaymentFormFooterListener
+    ) {
+        this.payButton = findViewById(R.id.button_ryft_pay)
+        this.cancelButton = findViewById(R.id.button_ryft_cancel)
+        this.usage = usage
+        this.payButtonTitleOverride = payButtonTitleOverride
 
-        payButton.initialise(context.getString(R.string.ryft_pay))
-        cancelButton.initialise(context.getString(R.string.ryft_cancel))
-
-        payButton.setOnSingleClickListener {
-            toggleButtons(enabled = false)
-            listener.onPayClicked()
-        }
-        cancelButton.setOnSingleClickListener {
-            toggleButtons(enabled = false)
-            listener.onCancelClicked()
-        }
-        transitionToAwaitingCardDetails()
+        payButton.initialise(
+            determinePayButtonTitle(),
+            enabled = false,
+            clickListener = {
+                toggleButtons(enabled = false)
+                listener.onPayClicked()
+            },
+            opacityWhenDisabled = 0.7F
+        )
+        cancelButton.initialise(
+            context.getString(R.string.ryft_cancel),
+            enabled = true,
+            clickListener = {
+                toggleButtons(enabled = false)
+                listener.onCancelClicked()
+            },
+            hideWhenDisabled = true
+        )
     }
 
     internal fun setState(state: State) {
         when (state) {
             State.AwaitingCardDetails -> transitionToAwaitingCardDetails()
             State.AwaitingGooglePayDetails -> transitionToAwaitingGooglePayDetails()
-            State.ReadyForCardPayment -> transitionToReadyForCardPayment()
-            State.TakingPayment -> transitionToTakingPayment()
+            State.ReadyToProcess -> transitionToReadyToProcess()
+            State.Processing -> transitionToProcessing()
         }
     }
 
     private fun transitionToAwaitingCardDetails() {
-        togglePayButton(enabled = false)
-        toggleCancelButton(enabled = true)
-        payButton.setText(context.getString(R.string.ryft_pay))
         state = State.AwaitingCardDetails
+        payButton.update(enabled = false)
+        cancelButton.update(enabled = true)
+        payButton.setText(determinePayButtonTitle())
     }
 
     private fun transitionToAwaitingGooglePayDetails() {
-        toggleButtons(enabled = false)
-        payButton.setText(context.getString(R.string.ryft_pay))
         state = State.AwaitingGooglePayDetails
-    }
-
-    private fun transitionToReadyForCardPayment() {
-        toggleButtons(enabled = true)
-        payButton.setText(context.getString(R.string.ryft_pay))
-        state = State.ReadyForCardPayment
-    }
-
-    private fun transitionToTakingPayment() {
         toggleButtons(enabled = false)
-        payButton.setText(context.getString(R.string.ryft_taking_payment))
-        state = State.TakingPayment
+        payButton.setText(determinePayButtonTitle())
+    }
+
+    private fun transitionToReadyToProcess() {
+        state = State.ReadyToProcess
+        toggleButtons(enabled = true)
+        payButton.setText(determinePayButtonTitle())
+    }
+
+    private fun transitionToProcessing() {
+        state = State.Processing
+        toggleButtons(enabled = false)
+        payButton.setText(determinePayButtonTitle())
     }
 
     private fun toggleButtons(enabled: Boolean) {
-        togglePayButton(enabled)
-        toggleCancelButton(enabled)
+        payButton.update(enabled)
+        cancelButton.update(enabled)
     }
 
-    private fun togglePayButton(enabled: Boolean) {
-        payButton.isEnabled = enabled
-        payButton.isClickable = enabled
-        payButton.alpha = if (enabled) 1F else 0.7F
-    }
-
-    private fun toggleCancelButton(enabled: Boolean) {
-        cancelButton.isEnabled = enabled
-        cancelButton.isClickable = enabled
-        cancelButton.visibility = if (enabled) View.VISIBLE else View.GONE
+    private fun determinePayButtonTitle(): String = when {
+        state == State.Processing -> context.getString(R.string.ryft_processing)
+        usage == RyftDropInUsage.SetupCard -> context.getString(R.string.ryft_save_card)
+        else -> payButtonTitleOverride?.ifBlank { null } ?: context.getString(R.string.ryft_pay)
     }
 
     internal enum class State {
         AwaitingCardDetails,
         AwaitingGooglePayDetails,
-        ReadyForCardPayment,
-        TakingPayment
+        ReadyToProcess,
+        Processing
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/delegate/RyftPaymentDelegate.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/delegate/RyftPaymentDelegate.kt
@@ -1,9 +1,15 @@
 package com.ryftpay.android.ui.delegate
 
 import android.view.View
+import com.ryftpay.android.ui.dropin.RyftDropInUsage
 
 internal interface RyftPaymentDelegate {
-    fun onViewCreated(root: View, showGooglePay: Boolean)
+    fun onViewCreated(
+        root: View,
+        usage: RyftDropInUsage,
+        payButtonTitleOverride: String?,
+        googlePayAvailable: Boolean
+    )
     fun onGooglePayPaymentProcessing()
     fun onGooglePayFailedOrCancelled()
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInConfiguration.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInConfiguration.kt
@@ -1,15 +1,12 @@
 package com.ryftpay.android.ui.dropin
 
 import android.os.Parcelable
-import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class RyftDropInConfiguration(
     val clientSecret: String,
     val subAccountId: String?,
+    val display: RyftDropInDisplayConfiguration = RyftDropInDisplayConfiguration.Default,
     val googlePayConfiguration: RyftDropInGooglePayConfiguration? = null
-) : Parcelable {
-    @IgnoredOnParcel
-    internal val googlePayEnabled = googlePayConfiguration != null
-}
+) : Parcelable

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInDisplayConfiguration.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInDisplayConfiguration.kt
@@ -1,0 +1,16 @@
+package com.ryftpay.android.ui.dropin
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class RyftDropInDisplayConfiguration(
+    val usage: RyftDropInUsage,
+    val payButtonTitle: String? = null
+) : Parcelable {
+    companion object {
+        internal val Default: RyftDropInDisplayConfiguration = RyftDropInDisplayConfiguration(
+            RyftDropInUsage.Payment
+        )
+    }
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInUsage.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftDropInUsage.kt
@@ -1,0 +1,10 @@
+package com.ryftpay.android.ui.dropin
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+enum class RyftDropInUsage : Parcelable {
+    Payment,
+    SetupCard
+}

--- a/ryft-ui/src/main/res/layout/partial_ryft_payment_form_body.xml
+++ b/ryft-ui/src/main/res/layout/partial_ryft_payment_form_body.xml
@@ -4,7 +4,7 @@
     android:id="@+id/partial_ryft_payment_form_body"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="136dp">
+    android:layout_height="wrap_content">
 
     <LinearLayout
         android:id="@+id/row_ryft_card_number"
@@ -52,7 +52,7 @@
         android:id="@+id/row_ryft_save_card"
         android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="16dp"
+        android:layout_height="wrap_content"
         android:layout_marginLeft="24dp"
         android:layout_marginRight="24dp"
         android:layout_marginBottom="16dp"
@@ -62,7 +62,15 @@
             android:id="@+id/check_box_ryft_save_card"
             android:layout_width="match_parent"
             android:layout_height="16dp"
-            layout="@layout/chk_ryft" />
+            layout="@layout/chk_ryft"/>
+
+        <TextView
+            android:id="@+id/text_ryft_save_card_disclaimer"
+            android:layout_width="match_parent"
+            android:layout_height="32dp"
+            android:visibility="gone"
+            android:text="@string/ryft_save_card_form_disclaimer"
+            style="@style/RyftDisclaimerText"/>
 
     </LinearLayout>
 

--- a/ryft-ui/src/main/res/values-en/strings.xml
+++ b/ryft-ui/src/main/res/values-en/strings.xml
@@ -6,15 +6,18 @@
     <string name="ryft_example_checkbox_text">Save card for future payments</string>
 
     <string name="ryft_pay">Pay now</string>
-    <string name="ryft_taking_payment">Taking payment…</string>
+    <string name="ryft_processing">Processing…</string>
+    <string name="ryft_save_card">Save card</string>
     <string name="ryft_or">or</string>
     <string name="ryft_retry">Retry</string>
     <string name="ryft_cancel">Cancel</string>
     <string name="ryft_card_number">Card number</string>
     <string name="ryft_card_expiry_date">MM/YY</string>
     <string name="ryft_card_cvc">CVC</string>
-    <string name="ryft_save_card">Save card for future payments</string>
+    <string name="ryft_save_card_check_box">Save card for future payments</string>
     <string name="ryft_payment_form_card_only_header_title">Credit / Debit Card</string>
+    <string name="ryft_save_card_form_title">Authorise Card</string>
+    <string name="ryft_save_card_form_disclaimer">By authorising your card, you consent to your details being stored securely for future payments</string>
     <string name="ryft_google_pay_error_message">Error loading Google Pay</string>
 
     <string name="ryft_bad_track_data">Your CVC or card expiration is invalid</string>

--- a/ryft-ui/src/main/res/values/strings.xml
+++ b/ryft-ui/src/main/res/values/strings.xml
@@ -6,15 +6,18 @@
     <string name="ryft_example_checkbox_text">Save card for future payments</string>
 
     <string name="ryft_pay">Pay now</string>
-    <string name="ryft_taking_payment">Taking payment…</string>
+    <string name="ryft_processing">Processing…</string>
+    <string name="ryft_save_card">Save card</string>
     <string name="ryft_or">or</string>
     <string name="ryft_retry">Retry</string>
     <string name="ryft_cancel">Cancel</string>
     <string name="ryft_card_number">Card number</string>
     <string name="ryft_card_expiry_date">MM/YY</string>
     <string name="ryft_card_cvc">CVC</string>
-    <string name="ryft_save_card">Save card for future payments</string>
+    <string name="ryft_save_card_check_box">Save card for future payments</string>
     <string name="ryft_payment_form_card_only_header_title">Credit / Debit Card</string>
+    <string name="ryft_save_card_form_title">Authorise Card</string>
+    <string name="ryft_save_card_form_disclaimer">By authorising your card, you consent to your details being stored securely for future payments</string>
     <string name="ryft_google_pay_error_message">Error loading Google Pay</string>
 
     <string name="ryft_bad_track_data">Your CVC or card expiration is invalid</string>

--- a/ryft-ui/src/main/res/values/styles.xml
+++ b/ryft-ui/src/main/res/values/styles.xml
@@ -89,6 +89,12 @@
         <item name="android:clickable">true</item>
     </style>
 
+    <style name="RyftDisclaimerText">
+        <item name="android:fontFamily">@font/ryft_nunito</item>
+        <item name="android:textSize">12sp</item>
+        <item name="android:textColor">@color/ryftCheckBoxText</item>
+    </style>
+
     <style name="RyftInputField">
         <item name="android:layout_height">40dp</item>
         <item name="android:paddingStart">16dp</item>

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/RyftDropInConfigurationTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/RyftDropInConfigurationTest.kt
@@ -1,12 +1,18 @@
 package com.ryftpay.android.ui.dropin
 
 import com.ryftpay.android.ui.TestData.CLIENT_SECRET
-import com.ryftpay.android.ui.TestData.GB_COUNTRY_CODE
-import com.ryftpay.android.ui.TestData.MERCHANT_NAME
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 
 internal class RyftDropInConfigurationTest {
+
+    @Test
+    internal fun `display should be default when not provided`() {
+        RyftDropInConfiguration(
+            clientSecret = CLIENT_SECRET,
+            subAccountId = null
+        ).display shouldBeEqualTo RyftDropInDisplayConfiguration.Default
+    }
 
     @Test
     internal fun `googlePayConfiguration should be null when not provided`() {
@@ -14,26 +20,5 @@ internal class RyftDropInConfigurationTest {
             clientSecret = CLIENT_SECRET,
             subAccountId = null
         ).googlePayConfiguration shouldBeEqualTo null
-    }
-
-    @Test
-    internal fun `googlePayEnabled should return true when google pay configuration is not null`() {
-        RyftDropInConfiguration(
-            clientSecret = CLIENT_SECRET,
-            subAccountId = null,
-            googlePayConfiguration = RyftDropInGooglePayConfiguration(
-                merchantName = MERCHANT_NAME,
-                merchantCountryCode = GB_COUNTRY_CODE
-            )
-        ).googlePayEnabled shouldBeEqualTo true
-    }
-
-    @Test
-    internal fun `googlePayEnabled should return false when google pay configuration is null`() {
-        RyftDropInConfiguration(
-            clientSecret = CLIENT_SECRET,
-            subAccountId = null,
-            googlePayConfiguration = null
-        ).googlePayEnabled shouldBeEqualTo false
     }
 }

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/RyftDropInDisplayConfigurationTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/RyftDropInDisplayConfigurationTest.kt
@@ -1,0 +1,22 @@
+package com.ryftpay.android.ui.dropin
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+internal class RyftDropInDisplayConfigurationTest {
+
+    @Test
+    internal fun `payButtonTitle should be null when not provided`() {
+        RyftDropInDisplayConfiguration(
+            usage = RyftDropInUsage.Payment
+        ).payButtonTitle shouldBeEqualTo null
+    }
+
+    @Test
+    internal fun `Default should be Payment usage with no pay button title`() {
+        RyftDropInDisplayConfiguration.Default shouldBeEqualTo RyftDropInDisplayConfiguration(
+            usage = RyftDropInUsage.Payment,
+            payButtonTitle = null
+        )
+    }
+}


### PR DESCRIPTION
- Allow the drop-in to be configured for account verification transactions so that it's clearer to customer's that the flow is for saving their card for future use as opposed to paying
- Allow pay button title to be configured (when the drop in is used for payments)

Screenshots:
| Dark | Light |
| - | - |
| ![image](https://user-images.githubusercontent.com/81687680/195889273-33048ddf-2c0c-4fc7-afb1-3fe2fe8e8660.png) | ![image](https://user-images.githubusercontent.com/81687680/195889348-7e0aac69-4ac3-48b7-a4d1-92937ec7540a.png) |