### PR TITLE
[R1175] Publish to maven central

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
         bundler-cache: true
 
     - name: Check
+      run: bundle exec fastlane check
       env:
         GH_PACKAGES_USERNAME_3DS: ${{ secrets.GH_PACKAGES_USERNAME_3DS }}
         GH_PACKAGES_PASS_3DS: ${{ secrets.GH_PACKAGES_PASS_3DS }}
-      run: bundle exec fastlane check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: build-and-test
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_PACKAGES_USERNAME_3DS: ${{ secrets.GH_PACKAGES_USERNAME_3DS }}
+      GH_PACKAGES_PASS_3DS: ${{ secrets.GH_PACKAGES_PASS_3DS }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        distribution: adopt
+        java-version: 11
+
+    - name: Assemble release
+      run: ./gradlew assembleRelease
+
+    - name: Generate source and javadoc jars
+      run: ./gradlew sourcesJar javadocJar
+
+    - name: Publish to MavenCentral
+      run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+      env:
+        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+        SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+        SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -55,12 +55,12 @@ jobs:
 
     - name: Run UI tests
       uses: reactivecircus/android-emulator-runner@v2
-      env:
-        GH_PACKAGES_USERNAME_3DS: ${{ secrets.GH_PACKAGES_USERNAME_3DS }}
-        GH_PACKAGES_PASS_3DS: ${{ secrets.GH_PACKAGES_PASS_3DS }}
       with:
         api-level: ${{ matrix.api-level }}
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         script: bundle exec fastlane uiTest
+      env:
+        GH_PACKAGES_USERNAME_3DS: ${{ secrets.GH_PACKAGES_USERNAME_3DS }}
+        GH_PACKAGES_PASS_3DS: ${{ secrets.GH_PACKAGES_PASS_3DS }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Ryft Android
 
-[![build-and-test](https://github.com/RyftPay/ryft-android/actions/workflows/build-and-test.yml/badge.svg?branch=master)](https://github.com/RyftPay/ryft-android/actions/workflows/build-and-test.yml) [![](https://jitpack.io/v/RyftPay/ryft-android.svg)](https://jitpack.io/#RyftPay/ryft-android) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![build-and-test](https://github.com/RyftPay/ryft-android/actions/workflows/build-and-test.yml/badge.svg?branch=master)](https://github.com/RyftPay/ryft-android/actions/workflows/build-and-test.yml)
+[![GitHub release](https://img.shields.io/github/release/RyftPay/ryft-android.svg?maxAge=60)](https://github.com/RyftPay/ryft-android/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 Ryft for Android allows you to accept in-app payments securely and safely using our customisable UI elements.
 
@@ -19,17 +21,17 @@ Note: the Google Pay environment is determined by your public API key.
 
 ## Installation
 
-Ryft Android is available via jitpack
+Ryft Android is available via Maven Central
 
-### Jitpack
+### Maven Central
 
-Add the jitpack repository to your project's `build.gradle`:
+Add the Maven Central repository to your project's `build.gradle`:
 
 ```groovy
 allprojects {
     repositories {
         // ...
-        maven { url 'https://jitpack.io' }
+        mavenCentral()
         // ...
     }
 }
@@ -40,7 +42,7 @@ Add the ryft-android dependency to your module's `build.gradle`:
 ```groovy
 dependencies {
     // ...
-    implementation 'com.github.RyftPay:ryft-android:1.3.0'
+    implementation 'com.ryftpay:ryft-android:1.3.0'
     // ...
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 
 plugins {
     id("org.jlleitschuh.gradle.ktlint") version "10.2.1" apply false
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }
 
 ext {
@@ -33,7 +34,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
         maven {
             url 'https://maven.pkg.github.com/checkout/checkout-3ds-sdk-android'
             credentials {
@@ -57,3 +57,5 @@ subprojects {
 task clean (type: Delete) {
     delete rootProject.buildDir
 }
+
+apply from: "publish-root.gradle"

--- a/publish-module.gradle
+++ b/publish-module.gradle
@@ -1,4 +1,5 @@
 apply plugin: "maven-publish"
+apply plugin: 'signing'
 
 task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
@@ -10,6 +11,14 @@ task sourcesJar(type: Jar) {
         // For Kotlin libraries
         from sourceSets.main.java.srcDirs
         from sourceSets.main.kotlin.srcDirs
+    }
+}
+
+task javadocJar(type: Jar) {
+    archiveClassifier.set('javadoc')
+    if (project.plugins.findPlugin("java-library")) {
+        // For Kotlin libraries
+        from javadoc
     }
 }
 
@@ -28,6 +37,10 @@ afterEvaluate { project ->
                 }
 
                 artifact sourcesJar
+                if (project.plugins.findPlugin("java-library")) {
+                    // For Kotlin libraries
+                    artifact javadocJar
+                }
 
                 pom {
                     name = project.artifactName
@@ -48,6 +61,12 @@ afterEvaluate { project ->
                             name = "Ryft"
                         }
                     }
+
+                    scm {
+                        connection = 'scm:git:github.com/RyftPay/ryft-android.git'
+                        developerConnection = 'scm:git:ssh://github.com/RyftPay/ryft-android.git'
+                        url = 'https://github.com/RyftPay/ryft-android/tree/master'
+                    }
                 }
             }
         }
@@ -55,7 +74,17 @@ afterEvaluate { project ->
 
     artifacts {
         archives sourcesJar
+        archives javadocJar
     }
+}
+
+signing {
+    useInMemoryPgpKeys(
+        rootProject.ext["signingKeyId"],
+        rootProject.ext["signingKey"],
+        rootProject.ext["signingPassword"],
+    )
+    sign publishing.publications
 }
 
 task cleanBuildPublishLocal(type: GradleBuild) {

--- a/publish-root.gradle
+++ b/publish-root.gradle
@@ -1,0 +1,18 @@
+ext["ossrhUsername"] = project.findProperty("ossrhUsername") ?: System.getenv('OSSRH_USERNAME') ?: ''
+ext["ossrhPassword"] = project.findProperty("ossrhPassword") ?: System.getenv('OSSRH_PASSWORD') ?: ''
+ext["sonatypeStagingProfileId"] = project.findProperty("sonatypeStagingProfileId") ?: System.getenv('SONATYPE_STAGING_PROFILE_ID') ?: ''
+ext["signingKeyId"] = project.findProperty("signingKeyId") ?: System.getenv('SIGNING_KEY_ID') ?: ''
+ext["signingPassword"] = project.findProperty("signingPassword") ?: System.getenv('SIGNING_PASSWORD') ?: ''
+ext["signingKey"] = project.findProperty("signingKey") ?: System.getenv('SIGNING_KEY') ?: ''
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
+}

--- a/ryft-core/build.gradle
+++ b/ryft-core/build.gradle
@@ -26,4 +26,4 @@ ext {
     artifactDescrption = "The Core module of the Ryft Android SDK"
 }
 
-apply from: "${rootDir}/publish.gradle"
+apply from: "${rootDir}/publish-module.gradle"

--- a/ryft-sample-app/build.gradle
+++ b/ryft-sample-app/build.gradle
@@ -39,5 +39,5 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
 
     // Ryft dependency
-    implementation 'com.github.RyftPay:ryft-android:1.2.0'
+    implementation 'com.ryftpay:ryft-android:1.2.0'
 }

--- a/ryft-sample-app/build.gradle
+++ b/ryft-sample-app/build.gradle
@@ -39,5 +39,5 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
 
     // Ryft dependency
-    implementation 'com.ryftpay:ryft-android:1.2.0'
+    implementation 'com.ryftpay:ryft-android:1.3.0'
 }

--- a/ryft-sdk/build.gradle
+++ b/ryft-sdk/build.gradle
@@ -35,4 +35,4 @@ ext {
     artifactDescrption = "The Ryft Android SDK"
 }
 
-apply from: "${rootDir}/publish.gradle"
+apply from: "${rootDir}/publish-module.gradle"

--- a/ryft-ui/build.gradle
+++ b/ryft-ui/build.gradle
@@ -67,4 +67,4 @@ ext {
     artifactDescrption = "The UI module of the Ryft Android SDK"
 }
 
-apply from: "${rootDir}/publish.gradle"
+apply from: "${rootDir}/publish-module.gradle"


### PR DESCRIPTION
- Add gradle nexus plugin to aid in publishing to maven central
- Add javadoc jar to ryft-core as it's required for publishing java libraries
- Add signing config for publishing
- Add new github action that automatically publishes releases once one is created
- Remove Jitpack integration
- Update references in README and sample app dependency to use maven central