### PR TITLE
[R1527] 3ds component

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,11 @@ Similarly to the drop-in, initialise the component within the fragment or activi
 class CheckoutFragment : Fragment() {
 
     // ...
-    // Declare RyftDropIn
+    // Declare RyftRequiredActionComponent
     private lateinit var ryftRequiredActionComponent: RyftRequiredActionComponent
     // ...
 
-    // Instantiate DefaultRyftDropIn in onCreate()
+    // Instantiate DefaultRyftRequiredActionComponent in onCreate()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // ...

--- a/README.md
+++ b/README.md
@@ -244,6 +244,138 @@ RyftDropInConfiguration.standardAccountPayment(
 )
 ```
 
+### Handling Required Actions
+
+Some payments will need additional steps after the initial payment attempt in order to be successfully authorized/settled (for example 3DS).
+Our drop-in payment controller will handle these steps automatically for you, however you may wish or need to handle any required actions outside of checkout or by yourself if using your own UI.
+
+A common use-case would be a MIT payment in which the bank still mandates that 3DS be performed to authorize the payment.
+In this case you will need to bring your customer back online in your app/website and have them complete the necessary step.
+
+You can use our `RyftRequiredActionComponent` by itself (without the drop-in) if you wish to facilitate this.
+
+#### Initialise the component
+
+Similarly to the drop-in, initialise the component within the fragment or activity which handles your checkout process, within the `onCreate()` function:
+
+```kotlin
+class CheckoutFragment : Fragment() {
+
+    // ...
+    // Declare RyftDropIn
+    private lateinit var ryftRequiredActionComponent: RyftRequiredActionComponent
+    // ...
+
+    // Instantiate DefaultRyftDropIn in onCreate()
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // ...
+        ryftRequiredActionComponent = DefaultRyftRequiredActionComponent(
+            // The calling fragment (activity is also supported)
+            fragment = this,
+            // The class you want to listen for the result (see "Implementing the RyftRequiredActionResultListener" below)
+            listener = this,
+            RyftPublicApiKey("<your public API key>")
+        )
+        // ...
+    }
+    
+    // ...
+}
+```
+
+#### Handle the required action
+
+In order to handle the required action, you simply have to call the method `handle()` whilst passing in your configuration and the required action:
+
+```kotlin
+class CheckoutFragment : Fragment() {
+
+    // ...
+    
+    // Example function to handle the required action
+    // Fetch 'requiredAction' from your backend
+    private fun handleRequiredAction(requiredAction: RequiredAction) {
+        ryftRequiredActionComponent.handle(
+            // Example config for sub account payments
+            RyftRequiredActionComponent.Configuration.subAccountPayment(
+                clientSecret = "<the client secret of the payment-session>",
+                subAccountId = "<the Id of the sub-account you are taking payments for>"
+            ),
+            // Example config for standard account payments
+            // RyftRequiredActionComponent.Configuration.standardAccountPayment(
+            //     clientSecret = "<the client secret of the payment-session>"
+            // ),
+            requiredAction
+        )
+    }
+    
+    // ...
+}
+```
+
+#### Implementing the RyftRequiredActionResultListener
+
+Once you've called `handle`, the component will trigger any necessary actions against the Ryft API to complete it.
+
+To handle the result, you have to specify a listener on construction that will implement the `RyftRequiredActionResultListener` interface:
+
+```kotlin
+interface RyftRequiredActionResultListener {
+    fun onRequiredActionResult(result: RyftRequiredActionResult)
+}
+```
+
+**Example:**
+
+```kotlin
+class CheckoutFragment : Fragment(), RyftDropInResultListener {
+
+    // ...
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // ...
+        ryftRequiredActionComponent = DefaultRyftRequiredActionComponent(
+            fragment = this,
+            listener = this, // This fragment will listen for the dropin result
+            RyftPublicApiKey("<your public API key>")
+        )
+        // ...
+    }
+    
+    // ...
+
+    override fun onRequiredActionResult(result: RyftRequiredActionResult) = when (result) {
+        // The required action was handled successfully - inspect the status to determine the next step
+        // `result.paymentSession` returns the updated payment session
+        is RyftRequiredActionResult.Success -> {
+            val status = result.paymentSession.status
+            // ...
+        }
+        // There was an error whilst handling the required action - show an alert to the customer
+        // `result.error.displayError` provides a human friendly message you can display
+        is RyftRequiredActionResult.Error -> {
+            AlertDialog.Builder(requireContext())
+                .setTitle("Error taking payment")
+                .setMessage(result.error.displayError)
+                .setPositiveButton("Try again") { _, _ ->
+                    // Fetch the latest 'requiredAction' from your backend
+                    handleRequiredAction(requiredAction)
+                }
+                .setNegativeButton("Cancel") { dialog, _ ->
+                    dialog.dismiss()
+                }
+                .create()
+                .show()
+        }
+    }
+    
+    // ...
+}
+```
+
+
 ### Customising the drop-in
 
 You can customise the title of the pay button by providing `payButtonTitle` within the `display` configuration when initialising the drop-in:

--- a/ryft-core/src/main/java/com/ryftpay/android/core/service/DefaultRyftPaymentService.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/service/DefaultRyftPaymentService.kt
@@ -13,6 +13,7 @@ import com.ryftpay.android.core.model.payment.PaymentSessionStatus
 import com.ryftpay.android.core.model.payment.RequiredActionType
 import com.ryftpay.android.core.service.listener.RyftLoadPaymentListener
 import com.ryftpay.android.core.service.listener.RyftPaymentResultListener
+import com.ryftpay.android.core.service.listener.RyftRawPaymentResultListener
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -92,6 +93,10 @@ class DefaultRyftPaymentService(
                 }
                 response.body()?.let {
                     val paymentSession = PaymentSession.from(it)
+                    if (listener is RyftRawPaymentResultListener) {
+                        listener.onRawPaymentResult(paymentSession)
+                        return
+                    }
                     if (paymentSession.status == PaymentSessionStatus.Approved ||
                         paymentSession.status == PaymentSessionStatus.Captured
                     ) {

--- a/ryft-core/src/main/java/com/ryftpay/android/core/service/listener/RyftRawPaymentResultListener.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/service/listener/RyftRawPaymentResultListener.kt
@@ -1,0 +1,20 @@
+package com.ryftpay.android.core.service.listener
+
+import com.ryftpay.android.core.model.payment.IdentifyAction
+import com.ryftpay.android.core.model.payment.PaymentSession
+import com.ryftpay.android.core.model.payment.PaymentSessionError
+
+// TODO refactor these listeners in next major version upgrade
+interface RyftRawPaymentResultListener : RyftPaymentResultListener {
+    fun onRawPaymentResult(response: PaymentSession)
+    override fun onPaymentApproved(response: PaymentSession) { }
+    override fun onPaymentRequiresRedirect(
+        returnUrl: String,
+        redirectUrl: String
+    ) { }
+    override fun onPaymentRequiresIdentification(
+        returnUrl: String,
+        identifyAction: IdentifyAction
+    ) { }
+    override fun onPaymentHasError(lastError: PaymentSessionError) { }
+}

--- a/ryft-ui/src/main/AndroidManifest.xml
+++ b/ryft-ui/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
             android:exported="true"
             android:launchMode="singleTask"
             android:theme="@style/Theme.AppCompat.RyftTransparent" />
+        <activity
+            android:name="com.ryftpay.android.ui.activity.RyftRequiredActionActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.AppCompat.RyftTransparent" />
         <meta-data
             android:name="com.google.android.gms.wallet.api.enabled"
             android:value="true" />

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/activity/RyftDropInActivity.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/activity/RyftDropInActivity.kt
@@ -48,7 +48,7 @@ internal class RyftDropInActivity : AppCompatActivity() {
                 )
             )
             supportFragmentManager.beginTransaction()
-                .replace(R.id.fragment_ryft_nav_host, navHostFragment)
+                .replace(R.id.fragment_ryft_nav_host_dropin, navHostFragment)
                 .setPrimaryNavigationFragment(navHostFragment)
                 .commit()
         }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/activity/RyftRequiredActionActivity.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/activity/RyftRequiredActionActivity.kt
@@ -1,0 +1,178 @@
+package com.ryftpay.android.ui.activity
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.appcompat.app.AppCompatActivity
+import com.ryftpay.android.core.client.RyftApiClientFactory
+import com.ryftpay.android.core.model.api.RyftPublicApiKey
+import com.ryftpay.android.core.model.error.RyftError
+import com.ryftpay.android.core.model.payment.IdentifyAction
+import com.ryftpay.android.core.model.payment.PaymentMethod
+import com.ryftpay.android.core.model.payment.PaymentSession
+import com.ryftpay.android.core.model.payment.RequiredAction
+import com.ryftpay.android.core.model.payment.RequiredActionType
+import com.ryftpay.android.core.service.DefaultRyftPaymentService
+import com.ryftpay.android.core.service.RyftPaymentService
+import com.ryftpay.android.core.service.listener.RyftRawPaymentResultListener
+import com.ryftpay.android.ui.client.Checkout3dsServiceFactory
+import com.ryftpay.android.ui.dropin.RyftPaymentError
+import com.ryftpay.android.ui.dropin.threeds.RyftRequiredActionComponent
+import com.ryftpay.android.ui.dropin.threeds.RyftRequiredActionResult
+import com.ryftpay.android.ui.extension.getParcelableArgs
+import com.ryftpay.android.ui.model.threeds.ThreeDsIdentificationResult
+import com.ryftpay.android.ui.model.threeds.ThreeDsIdentificationResultListener
+import com.ryftpay.android.ui.service.DefaultCheckoutThreeDsService
+import com.ryftpay.android.ui.service.ThreeDsService
+import com.ryftpay.android.ui.util.RequiredActionParceler
+import com.ryftpay.android.ui.util.RyftPublicApiKeyParceler
+import com.ryftpay.ui.R
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.WriteWith
+import java.lang.IllegalArgumentException
+
+internal class RyftRequiredActionActivity :
+    AppCompatActivity(),
+    ThreeDsIdentificationResultListener,
+    RyftRawPaymentResultListener {
+
+    private lateinit var ryftPaymentService: RyftPaymentService
+    private lateinit var threeDsService: ThreeDsService
+    private lateinit var clientSecret: String
+    private var subAccountId: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_ryft_required_action)
+        supportActionBar?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        val input = intent.getParcelableArgs(ARGUMENTS_INTENT_EXTRA, Arguments::class.java)
+            ?: throw IllegalArgumentException("No arguments provided to activity")
+        setupRyftPaymentService(input.publicApiKey)
+        clientSecret = input.configuration.clientSecret
+        subAccountId = input.configuration.subAccountId
+        handleRequiredAction(
+            input.requiredAction,
+            input.publicApiKey,
+            input.configuration.returnUrl
+        )
+    }
+
+    override fun onPause() {
+        super.onPause()
+        overridePendingTransition(0, 0)
+    }
+
+    override fun onThreeDsIdentificationResult(
+        result: ThreeDsIdentificationResult,
+        paymentMethodId: String
+    ) = ryftPaymentService.attemptPayment(
+        clientSecret = clientSecret,
+        paymentMethod = PaymentMethod.id(
+            id = paymentMethodId
+        ),
+        customerDetails = null,
+        subAccountId = subAccountId,
+        listener = this
+    )
+
+    override fun onRawPaymentResult(response: PaymentSession) = returnRequiredActionResult(
+        RyftRequiredActionResult.Success(response)
+    )
+
+    override fun onErrorObtainingPaymentResult(error: RyftError?, throwable: Throwable?) =
+        returnRequiredActionResult(
+            RyftRequiredActionResult.Error(
+                RyftPaymentError.from(throwable, context = this)
+            )
+        )
+
+    private fun setupRyftPaymentService(publicApiKey: RyftPublicApiKey) {
+        ryftPaymentService = DefaultRyftPaymentService(
+            RyftApiClientFactory(publicApiKey).createRyftApiClient()
+        )
+    }
+
+    private fun handleRequiredAction(
+        requiredAction: RequiredAction,
+        publicApiKey: RyftPublicApiKey,
+        returnUrl: String?
+    ) = when (requiredAction.type) {
+        RequiredActionType.Identify -> handleIdentification(
+            requiredAction.identify!!,
+            publicApiKey,
+            returnUrl
+        )
+        else -> returnRequiredActionResult(
+            RyftRequiredActionResult.Error(
+                RyftPaymentError(
+                    displayError = getString(
+                        R.string.ryft_unsupported_required_action_developer_error_message,
+                        requiredAction.type
+                    )
+                )
+            )
+        )
+    }
+
+    private fun handleIdentification(
+        identifyAction: IdentifyAction,
+        publicApiKey: RyftPublicApiKey,
+        returnUrl: String?
+    ) {
+        threeDsService = DefaultCheckoutThreeDsService(
+            Checkout3dsServiceFactory.create(
+                context = this,
+                publicApiKey.getEnvironment(),
+                returnUrl
+            )
+        )
+        threeDsService.handleIdentification(
+            identifyAction,
+            listener = this
+        )
+    }
+
+    private fun returnRequiredActionResult(requiredActionResult: RyftRequiredActionResult) {
+        setResult(
+            RESULT_OK,
+            Intent().apply {
+                putExtra(
+                    REQUIRED_ACTION_RESULT_INTENT_EXTRA,
+                    requiredActionResult
+                )
+            }
+        )
+        finish()
+    }
+
+    @Parcelize
+    private class Arguments(
+        val configuration: RyftRequiredActionComponent.Configuration,
+        val publicApiKey: @WriteWith<RyftPublicApiKeyParceler> RyftPublicApiKey,
+        val requiredAction: @WriteWith<RequiredActionParceler> RequiredAction
+    ) : Parcelable
+
+    companion object {
+        internal const val REQUIRED_ACTION_RESULT_INTENT_EXTRA = "com.ryftpay.android.ui.dropin.RyftRequiredActionResult"
+        private const val ARGUMENTS_INTENT_EXTRA = "com.ryftpay.android.ui.activity.RyftRequiredActionActivity.Arguments"
+
+        internal fun createIntent(
+            context: Context,
+            configuration: RyftRequiredActionComponent.Configuration,
+            publicApiKey: RyftPublicApiKey,
+            requiredAction: RequiredAction
+        ): Intent = Intent(context, RyftRequiredActionActivity::class.java).apply {
+            putExtra(
+                ARGUMENTS_INTENT_EXTRA,
+                Arguments(
+                    configuration,
+                    publicApiKey,
+                    requiredAction
+                )
+            )
+        }
+    }
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/activity/RyftRequiredActionActivity.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/activity/RyftRequiredActionActivity.kt
@@ -156,7 +156,7 @@ internal class RyftRequiredActionActivity :
     ) : Parcelable
 
     companion object {
-        internal const val REQUIRED_ACTION_RESULT_INTENT_EXTRA = "com.ryftpay.android.ui.dropin.RyftRequiredActionResult"
+        internal const val REQUIRED_ACTION_RESULT_INTENT_EXTRA = "com.ryftpay.android.ui.dropin.threeds.RyftRequiredActionResult"
         private const val ARGUMENTS_INTENT_EXTRA = "com.ryftpay.android.ui.activity.RyftRequiredActionActivity.Arguments"
 
         internal fun createIntent(

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/client/Checkout3dsServiceFactory.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/client/Checkout3dsServiceFactory.kt
@@ -15,7 +15,7 @@ internal object Checkout3dsServiceFactory {
     fun create(
         context: Context,
         ryftEnvironment: RyftEnvironment,
-        returnUrl: String
+        returnUrl: String?
     ): Checkout3DSService = Checkout3DSService(
         context,
         ryftEnvironment.toCheckoutComEnvironment(),
@@ -32,6 +32,6 @@ internal object Checkout3dsServiceFactory {
                 )
             )
         ),
-        appUrl = Uri.parse(returnUrl)
+        appUrl = if (returnUrl != null) Uri.parse(returnUrl) else null
     )
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftPaymentError.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/RyftPaymentError.kt
@@ -10,7 +10,7 @@ import java.io.IOException
 
 @Parcelize
 class RyftPaymentError(
-    val paymentSessionError: PaymentSessionError?,
+    val paymentSessionError: PaymentSessionError? = null,
     val displayError: String
 ) : Parcelable {
 
@@ -20,7 +20,6 @@ class RyftPaymentError(
         private const val UNEXPECTED_ERROR_MESSAGE = "An unexpected error occurred"
 
         val Unexpected = RyftPaymentError(
-            paymentSessionError = null,
             displayError = UNEXPECTED_ERROR_MESSAGE
         )
 
@@ -50,8 +49,7 @@ class RyftPaymentError(
                 context.getString(R.string.ryft_unknown_error)
             }
             return RyftPaymentError(
-                paymentSessionError = null,
-                displayError
+                displayError = displayError
             )
         }
     }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/threeds/DefaultRyftRequiredActionComponent.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/threeds/DefaultRyftRequiredActionComponent.kt
@@ -1,0 +1,57 @@
+package com.ryftpay.android.ui.dropin.threeds
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.fragment.app.Fragment
+import com.ryftpay.android.core.model.api.RyftPublicApiKey
+import com.ryftpay.android.core.model.payment.RequiredAction
+import com.ryftpay.android.ui.activity.RyftRequiredActionActivity
+
+class DefaultRyftRequiredActionComponent : RyftRequiredActionComponent {
+
+    private val launcher: ActivityResultLauncher<Intent>
+    private val context: Context
+    private val apiKey: RyftPublicApiKey
+
+    constructor(
+        fragment: Fragment,
+        listener: RyftRequiredActionResultListener,
+        publicApiKey: RyftPublicApiKey
+    ) {
+        launcher = fragment.registerForActivityResult(
+            RyftRequiredActionResultContract(),
+            listener::onRequiredActionResult
+        )
+        context = fragment.requireContext()
+        apiKey = publicApiKey
+    }
+
+    constructor(
+        activity: ComponentActivity,
+        listener: RyftRequiredActionResultListener,
+        publicApiKey: RyftPublicApiKey
+    ) {
+        this.launcher = activity.registerForActivityResult(
+            RyftRequiredActionResultContract(),
+            listener::onRequiredActionResult
+        )
+        context = activity
+        apiKey = publicApiKey
+    }
+
+    override fun handle(
+        configuration: RyftRequiredActionComponent.Configuration,
+        requiredAction: RequiredAction
+    ) {
+        launcher.launch(
+            RyftRequiredActionActivity.createIntent(
+                context,
+                configuration,
+                apiKey,
+                requiredAction
+            )
+        )
+    }
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/threeds/RyftRequiredActionComponent.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/threeds/RyftRequiredActionComponent.kt
@@ -1,0 +1,39 @@
+package com.ryftpay.android.ui.dropin.threeds
+
+import android.os.Parcelable
+import com.ryftpay.android.core.model.payment.RequiredAction
+import kotlinx.parcelize.Parcelize
+
+interface RyftRequiredActionComponent {
+    fun handle(
+        configuration: Configuration,
+        requiredAction: RequiredAction
+    )
+
+    @Parcelize
+    class Configuration private constructor(
+        internal val clientSecret: String,
+        internal val subAccountId: String?,
+        internal val returnUrl: String?
+    ) : Parcelable {
+        companion object {
+            fun subAccountPayment(
+                clientSecret: String,
+                subAccountId: String,
+                returnUrl: String? = null
+            ): Configuration = Configuration(
+                clientSecret,
+                subAccountId,
+                returnUrl
+            )
+            fun standardAccountPayment(
+                clientSecret: String,
+                returnUrl: String? = null
+            ): Configuration = Configuration(
+                clientSecret,
+                subAccountId = null,
+                returnUrl
+            )
+        }
+    }
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/threeds/RyftRequiredActionResult.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/threeds/RyftRequiredActionResult.kt
@@ -1,0 +1,16 @@
+package com.ryftpay.android.ui.dropin.threeds
+
+import android.os.Parcelable
+import com.ryftpay.android.core.model.payment.PaymentSession
+import com.ryftpay.android.ui.dropin.RyftPaymentError
+import com.ryftpay.android.ui.util.PaymentSessionParceler
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.WriteWith
+
+sealed class RyftRequiredActionResult : Parcelable {
+    @Parcelize
+    class Success(val paymentSession: @WriteWith<PaymentSessionParceler> PaymentSession) : RyftRequiredActionResult()
+
+    @Parcelize
+    class Error(val error: RyftPaymentError) : RyftRequiredActionResult()
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/threeds/RyftRequiredActionResultContract.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/threeds/RyftRequiredActionResultContract.kt
@@ -1,0 +1,24 @@
+package com.ryftpay.android.ui.dropin.threeds
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import com.ryftpay.android.ui.activity.RyftRequiredActionActivity
+import com.ryftpay.android.ui.dropin.RyftPaymentError
+import com.ryftpay.android.ui.extension.getParcelableArgs
+
+internal class RyftRequiredActionResultContract : ActivityResultContract<Intent, RyftRequiredActionResult>() {
+    override fun createIntent(context: Context, input: Intent): Intent = input
+
+    override fun parseResult(resultCode: Int, intent: Intent?): RyftRequiredActionResult =
+        when (resultCode) {
+            Activity.RESULT_OK -> {
+                intent?.extras?.getParcelableArgs(
+                    RyftRequiredActionActivity.REQUIRED_ACTION_RESULT_INTENT_EXTRA,
+                    RyftRequiredActionResult::class.java
+                ) ?: RyftRequiredActionResult.Error(RyftPaymentError.Unexpected)
+            }
+            else -> RyftRequiredActionResult.Error(RyftPaymentError.Unexpected)
+        }
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/threeds/RyftRequiredActionResultListener.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/dropin/threeds/RyftRequiredActionResultListener.kt
@@ -1,0 +1,5 @@
+package com.ryftpay.android.ui.dropin.threeds
+
+interface RyftRequiredActionResultListener {
+    fun onRequiredActionResult(result: RyftRequiredActionResult)
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/util/IdentifyActionParceler.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/util/IdentifyActionParceler.kt
@@ -1,0 +1,21 @@
+package com.ryftpay.android.ui.util
+
+import android.os.Parcel
+import com.ryftpay.android.core.model.payment.IdentifyAction
+import kotlinx.parcelize.Parceler
+
+internal object IdentifyActionParceler : Parceler<IdentifyAction> {
+    override fun create(parcel: Parcel): IdentifyAction = IdentifyAction(
+        sessionId = parcel.readString()!!,
+        sessionSecret = parcel.readString()!!,
+        scheme = parcel.readString()!!,
+        paymentMethodId = parcel.readString()!!
+    )
+
+    override fun IdentifyAction.write(parcel: Parcel, flags: Int) {
+        parcel.writeString(sessionId)
+        parcel.writeString(sessionSecret)
+        parcel.writeString(scheme)
+        parcel.writeString(paymentMethodId)
+    }
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/util/PaymentSessionParceler.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/util/PaymentSessionParceler.kt
@@ -1,0 +1,63 @@
+package com.ryftpay.android.ui.util
+
+import android.os.Parcel
+import com.ryftpay.android.core.model.payment.PaymentSession
+import com.ryftpay.android.core.model.payment.PaymentSessionError
+import com.ryftpay.android.core.model.payment.PaymentSessionStatus
+import com.ryftpay.android.ui.util.RequiredActionParceler.write
+import kotlinx.parcelize.Parceler
+import java.util.Currency
+
+internal object PaymentSessionParceler : Parceler<PaymentSession> {
+    override fun create(parcel: Parcel): PaymentSession {
+        val id = parcel.readString()!!
+        val amount = parcel.readInt()
+        val currency = Currency.getInstance(parcel.readString()!!)
+        val returnUrl = parcel.readString()!!
+        val status = PaymentSessionStatus.valueOf(parcel.readString()!!)
+        val customerEmail = parcel.readString()
+        val maybeLastError = parcel.readString()
+        val lastError = if (maybeLastError != null) {
+            PaymentSessionError.valueOf(maybeLastError)
+        } else {
+            null
+        }
+        val requiredAction = if (parcel.readInt() != 0) {
+            RequiredActionParceler.create(parcel)
+        } else {
+            null
+        }
+        val createdTimestamp = parcel.readLong()
+        val lastUpdatedTimestamp = parcel.readLong()
+        return PaymentSession(
+            id,
+            amount,
+            currency,
+            returnUrl,
+            status,
+            customerEmail,
+            lastError,
+            requiredAction,
+            createdTimestamp,
+            lastUpdatedTimestamp
+        )
+    }
+
+    override fun PaymentSession.write(parcel: Parcel, flags: Int) {
+        parcel.writeString(id)
+        parcel.writeInt(amount)
+        parcel.writeString(currency.currencyCode)
+        parcel.writeString(returnUrl)
+        parcel.writeString(status.toString())
+        parcel.writeString(customerEmail)
+        parcel.writeString(lastError?.toString())
+        if (requiredAction == null) {
+            parcel.writeInt(0)
+        } else {
+            parcel.writeInt(1)
+            requiredAction!!.write(parcel, flags)
+        }
+        parcel.writeLong(createdTimestamp)
+        parcel.writeLong(lastUpdatedTimestamp)
+    }
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/util/RequiredActionParceler.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/util/RequiredActionParceler.kt
@@ -1,0 +1,30 @@
+package com.ryftpay.android.ui.util
+
+import android.os.Parcel
+import com.ryftpay.android.core.model.payment.RequiredAction
+import com.ryftpay.android.core.model.payment.RequiredActionType
+import com.ryftpay.android.ui.util.IdentifyActionParceler.write
+import kotlinx.parcelize.Parceler
+
+internal object RequiredActionParceler : Parceler<RequiredAction> {
+    override fun create(parcel: Parcel): RequiredAction = RequiredAction(
+        type = RequiredActionType.valueOf(parcel.readString()!!),
+        url = parcel.readString(),
+        identify = if (parcel.readInt() != 0) {
+            IdentifyActionParceler.create(parcel)
+        } else {
+            null
+        }
+    )
+
+    override fun RequiredAction.write(parcel: Parcel, flags: Int) {
+        parcel.writeString(type.toString())
+        parcel.writeString(url)
+        if (identify == null) {
+            parcel.writeInt(0)
+        } else {
+            parcel.writeInt(1)
+            identify!!.write(parcel, flags)
+        }
+    }
+}

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/util/RyftPublicApiKeyParceler.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/util/RyftPublicApiKeyParceler.kt
@@ -3,15 +3,11 @@ package com.ryftpay.android.ui.util
 import android.os.Parcel
 import com.ryftpay.android.core.model.api.RyftPublicApiKey
 import kotlinx.parcelize.Parceler
-import java.lang.IllegalArgumentException
 
 internal object RyftPublicApiKeyParceler : Parceler<RyftPublicApiKey> {
-    override fun create(parcel: Parcel): RyftPublicApiKey {
-        return RyftPublicApiKey(
-            value = parcel.readString()
-                ?: throw IllegalArgumentException("Invalid API key, string in parcel was null")
-        )
-    }
+    override fun create(parcel: Parcel): RyftPublicApiKey = RyftPublicApiKey(
+        value = parcel.readString()!!
+    )
 
     override fun RyftPublicApiKey.write(parcel: Parcel, flags: Int) {
         parcel.writeString(value)

--- a/ryft-ui/src/main/res/layout/activity_ryft_dropin.xml
+++ b/ryft-ui/src/main/res/layout/activity_ryft_dropin.xml
@@ -6,7 +6,7 @@
     android:orientation="vertical">
 
     <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragment_ryft_nav_host"
+        android:id="@+id/fragment_ryft_nav_host_dropin"
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>

--- a/ryft-ui/src/main/res/layout/activity_ryft_required_action.xml
+++ b/ryft-ui/src/main/res/layout/activity_ryft_required_action.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/container_ryft_required_action"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"/>

--- a/ryft-ui/src/main/res/values-en/strings.xml
+++ b/ryft-ui/src/main/res/values-en/strings.xml
@@ -22,6 +22,7 @@
     <string name="ryft_payment_not_found_developer_error_message">Developer error - payment not found</string>
     <string name="ryft_invalid_client_secret_developer_error_message">Developer error - invalid client secret</string>
     <string name="ryft_invalid_api_key_developer_error_message">Developer error - invalid api key</string>
+    <string name="ryft_unsupported_required_action_developer_error_message">Developer error - unsupported required action: %1$s</string>
 
     <string name="ryft_bad_track_data">Your CVC or card expiration is invalid</string>
     <string name="ryft_declined_do_not_honour">Your bank has declined this card</string>

--- a/ryft-ui/src/main/res/values/strings.xml
+++ b/ryft-ui/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="ryft_payment_not_found_developer_error_message">Developer error - payment not found</string>
     <string name="ryft_invalid_client_secret_developer_error_message">Developer error - invalid client secret</string>
     <string name="ryft_invalid_api_key_developer_error_message">Developer error - invalid api key</string>
+    <string name="ryft_unsupported_required_action_developer_error_message">Developer error - unsupported required action: %1$s</string>
 
     <string name="ryft_bad_track_data">Your CVC or card expiration is invalid</string>
     <string name="ryft_declined_do_not_honour">Your bank has declined this card</string>

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/threeds/DefaultRyftRequiredActionComponentTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/threeds/DefaultRyftRequiredActionComponentTest.kt
@@ -1,4 +1,4 @@
-package com.ryftpay.android.ui.dropin
+package com.ryftpay.android.ui.dropin.threeds
 
 import android.content.Intent
 import androidx.activity.ComponentActivity
@@ -9,16 +9,16 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Test
 
-internal class DefaultRyftDropInTest {
+internal class DefaultRyftRequiredActionComponentTest {
 
     private val fragment = mockk<Fragment>(relaxed = true)
     private val activity = mockk<ComponentActivity>(relaxed = true)
-    private val listener = mockk<RyftDropInResultListener>(relaxed = true)
+    private val listener = mockk<RyftRequiredActionResultListener>(relaxed = true)
     private val publicApiKey = RyftPublicApiKey("pk_sandbox_123")
 
     @Test
-    internal fun `DefaultRyftDropIn should register fragment for activity on construction`() {
-        DefaultRyftDropIn(
+    internal fun `DefaultRyftRequiredActionComponent should register fragment for activity on construction`() {
+        DefaultRyftRequiredActionComponent(
             fragment,
             listener,
             publicApiKey
@@ -26,8 +26,8 @@ internal class DefaultRyftDropInTest {
 
         verify {
             fragment.registerForActivityResult(
-                match<ActivityResultContract<Intent, RyftPaymentResult>> {
-                    it is RyftDropInResultContract
+                match<ActivityResultContract<Intent, RyftRequiredActionResult>> {
+                    it is RyftRequiredActionResultContract
                 },
                 any()
             )
@@ -35,8 +35,8 @@ internal class DefaultRyftDropInTest {
     }
 
     @Test
-    internal fun `DefaultRyftDropIn should register activity for activity on construction`() {
-        DefaultRyftDropIn(
+    internal fun `DefaultRyftRequiredActionComponent should register activity for activity on construction`() {
+        DefaultRyftRequiredActionComponent(
             activity,
             listener,
             publicApiKey
@@ -44,8 +44,8 @@ internal class DefaultRyftDropInTest {
 
         verify {
             activity.registerForActivityResult(
-                match<ActivityResultContract<Intent, RyftPaymentResult>> {
-                    it is RyftDropInResultContract
+                match<ActivityResultContract<Intent, RyftRequiredActionResult>> {
+                    it is RyftRequiredActionResultContract
                 },
                 any()
             )

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/threeds/RyftRequiredActionComponentTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/dropin/threeds/RyftRequiredActionComponentTest.kt
@@ -1,0 +1,43 @@
+package com.ryftpay.android.ui.dropin.threeds
+
+import com.ryftpay.android.ui.TestData.CLIENT_SECRET
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+internal class RyftRequiredActionComponentTest {
+
+    @Test
+    internal fun `subAccountPayment should return expected clientSecret and subAccountId`() {
+        val subAccountId = "ac_123"
+        val subAccountPaymentConfig = RyftRequiredActionComponent.Configuration.subAccountPayment(
+            clientSecret = CLIENT_SECRET,
+            subAccountId = subAccountId
+        )
+        subAccountPaymentConfig.clientSecret shouldBeEqualTo CLIENT_SECRET
+        subAccountPaymentConfig.subAccountId shouldBeEqualTo subAccountId
+    }
+
+    @Test
+    internal fun `subAccountPayment should use null returnUrl when not provided`() {
+        RyftRequiredActionComponent.Configuration.subAccountPayment(
+            clientSecret = CLIENT_SECRET,
+            subAccountId = "ac_123"
+        ).returnUrl shouldBeEqualTo null
+    }
+
+    @Test
+    internal fun `standardAccountPayment should return expected clientSecret with null subAccountId`() {
+        val standardAccountPaymentConfig = RyftRequiredActionComponent.Configuration.standardAccountPayment(
+            clientSecret = CLIENT_SECRET
+        )
+        standardAccountPaymentConfig.clientSecret shouldBeEqualTo CLIENT_SECRET
+        standardAccountPaymentConfig.subAccountId shouldBeEqualTo null
+    }
+
+    @Test
+    internal fun `standardAccountPayment should use null returnUrl when not provided`() {
+        RyftRequiredActionComponent.Configuration.standardAccountPayment(
+            clientSecret = CLIENT_SECRET
+        ).returnUrl shouldBeEqualTo null
+    }
+}


### PR DESCRIPTION
- Add new RyftRequiredActionComponent to handle the required action of a payment session (3ds)
- Add new payment result listener for accessing the raw payment session result to return from the new component
- Add new parceler implementations for objects from ryft-core can be parceled as inputs and outputs from the new component's activity