### PR TITLE
[Tech] Upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -26,7 +26,7 @@ ext {
     kotlin_jvm_target = '1.8'
     min_sdk_version = 21
     compile_sdk_version = 33
-    target_sdk_version = 33
+    target_sdk_version = 34
     build_tools_version = '31.0.0'
 }
 
@@ -36,13 +36,6 @@ allprojects {
         mavenLocal()
         google()
         mavenCentral()
-        maven {
-            url 'https://maven.pkg.github.com/checkout/checkout-3ds-sdk-android'
-            credentials {
-                username = project.findProperty("ghUsername") ?: System.getenv('GH_USERNAME')
-                password = project.findProperty("ghPackagesToken") ?: System.getenv('GH_PACKAGES_TOKEN')
-            }
-        }
     }
 }
 
@@ -56,7 +49,7 @@ subprojects {
     }
 }
 
-task clean (type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.enableJetifier=true
 android.useAndroidX=true
+org.gradle.jvmargs=-Xmx4g -Xms1g

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Oct 27 10:07:17 BST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/ryft-sample-app/build.gradle
+++ b/ryft-sample-app/build.gradle
@@ -30,6 +30,21 @@ android {
     kotlinOptions {
         jvmTarget = rootProject.ext.kotlin_jvm_target
     }
+    lintOptions {
+        // Disables a linting error that is a false positive (or one of our dependencies is using it)
+        disable 'NotificationPermission'
+    }
+}
+
+// TODO remove once ryft-android is upgraded from 1.4.0
+repositories {
+    maven {
+        url 'https://maven.pkg.github.com/checkout/checkout-3ds-sdk-android'
+        credentials {
+            username = project.findProperty("ghUsername") ?: System.getenv('GH_USERNAME')
+            password = project.findProperty("ghPackagesToken") ?: System.getenv('GH_PACKAGES_TOKEN')
+        }
+    }
 }
 
 dependencies {

--- a/ryft-sdk/build.gradle
+++ b/ryft-sdk/build.gradle
@@ -8,8 +8,7 @@ android {
     namespace 'com.ryftpay.android'
 
     compileSdk rootProject.ext.compile_sdk_version
-    compileSdkVersion rootProject.ext.compile_sdk_version
-    buildToolsVersion rootProject.ext.build_tools_version
+    buildToolsVersion = rootProject.ext.build_tools_version
 
     defaultConfig {
         minSdk rootProject.ext.min_sdk_version

--- a/ryft-ui/build.gradle
+++ b/ryft-ui/build.gradle
@@ -8,8 +8,7 @@ android {
     namespace 'com.ryftpay.ui'
 
     compileSdk rootProject.ext.compile_sdk_version
-    compileSdkVersion rootProject.ext.compile_sdk_version
-    buildToolsVersion rootProject.ext.build_tools_version
+    buildToolsVersion = rootProject.ext.build_tools_version
 
     defaultConfig {
         minSdk rootProject.ext.min_sdk_version
@@ -54,7 +53,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
-    implementation 'com.checkout:checkout-sdk-3ds-android:2.0.3'
+    implementation 'com.checkout:checkout-sdk-3ds-android:3.2.0'
     implementation 'com.google.android.gms:play-services-wallet:19.1.0'
     implementation 'com.google.android.material:material:1.7.0'
 

--- a/ryft-ui/build.gradle
+++ b/ryft-ui/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     testImplementation 'org.json:json:20210307'
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 
-    androidTestImplementation 'androidx.fragment:fragment-testing:1.5.4'
+    androidTestImplementation 'androidx.fragment:fragment-testing:1.6.2'
     androidTestImplementation 'androidx.navigation:navigation-testing:2.5.3'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/fragment/RyftPaymentFragment.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/fragment/RyftPaymentFragment.kt
@@ -10,7 +10,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.VisibleForTesting
-import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import com.google.android.gms.common.api.ApiException
@@ -401,7 +400,7 @@ internal class RyftPaymentFragment :
     }
 
     companion object {
-        @VisibleForTesting(otherwise = PRIVATE)
+        @VisibleForTesting
         internal const val ARGUMENTS_BUNDLE_KEY = "Arguments"
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/model/threeds/ThreeDsIdentificationResult.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/model/threeds/ThreeDsIdentificationResult.kt
@@ -1,7 +1,7 @@
 package com.ryftpay.android.ui.model.threeds
 
+import com.checkout.threeds.domain.model.AuthenticationCompleted
 import com.checkout.threeds.domain.model.AuthenticationResult
-import com.checkout.threeds.domain.model.ResultType
 
 internal sealed class ThreeDsIdentificationResult {
     object Success : ThreeDsIdentificationResult()
@@ -9,12 +9,15 @@ internal sealed class ThreeDsIdentificationResult {
     object Error : ThreeDsIdentificationResult()
 
     companion object {
+        private const val SuccessfulStatus = "Y"
         internal fun fromCheckoutResult(
             authenticationResult: AuthenticationResult
-        ): ThreeDsIdentificationResult = when (authenticationResult.resultType) {
-            ResultType.Successful -> Success
-            ResultType.Failed -> Fail
-            ResultType.Error -> Error
+        ): ThreeDsIdentificationResult = when (authenticationResult) {
+            is AuthenticationCompleted -> when (authenticationResult.transactionStatus) {
+                SuccessfulStatus -> Success
+                else -> Fail
+            }
+            else -> Error
         }
     }
 }

--- a/ryft-ui/src/main/java/com/ryftpay/android/ui/model/threeds/ThreeDsIdentificationResult.kt
+++ b/ryft-ui/src/main/java/com/ryftpay/android/ui/model/threeds/ThreeDsIdentificationResult.kt
@@ -9,12 +9,16 @@ internal sealed class ThreeDsIdentificationResult {
     object Error : ThreeDsIdentificationResult()
 
     companion object {
-        private const val SuccessfulStatus = "Y"
+        private val SuccessfulStatuses = setOf(
+            "Y",
+            "I",
+            "A"
+        )
         internal fun fromCheckoutResult(
             authenticationResult: AuthenticationResult
         ): ThreeDsIdentificationResult = when (authenticationResult) {
             is AuthenticationCompleted -> when (authenticationResult.transactionStatus) {
-                SuccessfulStatus -> Success
+                in SuccessfulStatuses -> Success
                 else -> Fail
             }
             else -> Error

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/model/threeds/ThreeDsIdentificationResultTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/model/threeds/ThreeDsIdentificationResultTest.kt
@@ -49,11 +49,11 @@ internal class ThreeDsIdentificationResultTest {
     private fun checkoutThreeDsTransactionStatusesToRyftThreeDsResults(): Array<Any> = arrayOf(
         arrayOf("N", ThreeDsIdentificationResult.Fail),
         arrayOf("U", ThreeDsIdentificationResult.Fail),
-        arrayOf("A", ThreeDsIdentificationResult.Fail),
         arrayOf("C", ThreeDsIdentificationResult.Fail),
         arrayOf("D", ThreeDsIdentificationResult.Fail),
         arrayOf("R", ThreeDsIdentificationResult.Fail),
-        arrayOf("I", ThreeDsIdentificationResult.Fail),
+        arrayOf("A", ThreeDsIdentificationResult.Success),
+        arrayOf("I", ThreeDsIdentificationResult.Success),
         arrayOf("Y", ThreeDsIdentificationResult.Success)
     )
 }

--- a/ryft-ui/src/test/java/com/ryftpay/android/ui/model/threeds/ThreeDsIdentificationResultTest.kt
+++ b/ryft-ui/src/test/java/com/ryftpay/android/ui/model/threeds/ThreeDsIdentificationResultTest.kt
@@ -1,5 +1,6 @@
 package com.ryftpay.android.ui.model.threeds
 
+import com.checkout.threeds.domain.model.AuthenticationCompleted
 import com.checkout.threeds.domain.model.AuthenticationResult
 import com.checkout.threeds.domain.model.ResultType
 import io.mockk.every
@@ -14,26 +15,45 @@ import org.junit.runner.RunWith
 internal class ThreeDsIdentificationResultTest {
 
     @Test
-    @Parameters(method = "checkoutThreeDsResultTypesToRyftThreeDsResults")
-    internal fun `fromCheckoutResult should return expected result`(
-        authenticationResultType: ResultType,
-        expected: ThreeDsIdentificationResult
-    ) {
+    internal fun `fromCheckoutResult should return expected result when AuthenticationError`() {
         val authenticationResult = mockk<AuthenticationResult>(relaxed = true)
         every {
             authenticationResult.resultType
         } answers {
-            authenticationResultType
+            ResultType.Error
         }
 
         ThreeDsIdentificationResult.fromCheckoutResult(
             authenticationResult
+        ) shouldBeEqualTo ThreeDsIdentificationResult.Error
+    }
+
+    @Test
+    @Parameters(method = "checkoutThreeDsTransactionStatusesToRyftThreeDsResults")
+    internal fun `fromCheckoutResult should return expected result when AuthenticationCompleted`(
+        transactionStatus: String,
+        expected: ThreeDsIdentificationResult
+    ) {
+        val authenticationCompleted = mockk<AuthenticationCompleted>(relaxed = true)
+        every {
+            authenticationCompleted.transactionStatus
+        } answers {
+            transactionStatus
+        }
+
+        ThreeDsIdentificationResult.fromCheckoutResult(
+            authenticationCompleted
         ) shouldBeEqualTo expected
     }
 
-    private fun checkoutThreeDsResultTypesToRyftThreeDsResults(): Array<Any> = arrayOf(
-        arrayOf(ResultType.Error, ThreeDsIdentificationResult.Error),
-        arrayOf(ResultType.Failed, ThreeDsIdentificationResult.Fail),
-        arrayOf(ResultType.Successful, ThreeDsIdentificationResult.Success)
+    private fun checkoutThreeDsTransactionStatusesToRyftThreeDsResults(): Array<Any> = arrayOf(
+        arrayOf("N", ThreeDsIdentificationResult.Fail),
+        arrayOf("U", ThreeDsIdentificationResult.Fail),
+        arrayOf("A", ThreeDsIdentificationResult.Fail),
+        arrayOf("C", ThreeDsIdentificationResult.Fail),
+        arrayOf("D", ThreeDsIdentificationResult.Fail),
+        arrayOf("R", ThreeDsIdentificationResult.Fail),
+        arrayOf("I", ThreeDsIdentificationResult.Fail),
+        arrayOf("Y", ThreeDsIdentificationResult.Success)
     )
 }


### PR DESCRIPTION
- Upgrade checkout com dependency to latest version, removing their repository now that it's published to maven central (the sample app still needs this repo whilst it's referencing the current Ryft SDK version, which still uses the previous dependency version)
- Upgrade kotlin version to 1.8.0
- Upgrade AGP plugin to 7.4.2 and gradle wrapper to 7.5
- Upgrade target SDK version to 34
- Upgrade fragment testing dependency to fix ui tests after other upgrades
- Fix a few warnings in gradle files
- Increase heap size to help with build job OOM errors