### PR TITLE
[Tech] Bump version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,4 +23,4 @@ jobs:
       env:
         GH_USERNAME: ${{ secrets.GH_PACKAGES_USERNAME_3DS }}
         GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_PASS_3DS }}
-      run: ./gradlew check
+      run: ./gradlew -x ryft-sample-app:check check

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,4 @@ jobs:
         java-version: 11
 
     - name: Check
-      env:
-        GH_USERNAME: ${{ secrets.GH_PACKAGES_USERNAME_3DS }}
-        GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_PASS_3DS }}
       run: ./gradlew -x ryft-sample-app:check check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
-    env:
-      GH_USERNAME: ${{ secrets.GH_PACKAGES_USERNAME_3DS }}
-      GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_PASS_3DS }}
-
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: build-and-test
+name: publish
 
 on:
   release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         java-version: 11
 
     - name: Assemble release
-      run: ./gradlew assembleRelease
+      run: ./gradlew -x ryft-sample-app:assembleRelease assembleRelease
 
     - name: Generate source and javadoc jars
       run: ./gradlew sourcesJar javadocJar

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -55,6 +55,3 @@ jobs:
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
         script: ./gradlew -x ryft-sample-app:connectedCheck connectedCheck
-      env:
-        GH_USERNAME: ${{ secrets.GH_PACKAGES_USERNAME_3DS }}
-        GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_PASS_3DS }}

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -54,7 +54,7 @@ jobs:
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true
-        script: ./gradlew connectedCheck
+        script: ./gradlew -x ryft-sample-app:connectedCheck connectedCheck
       env:
         GH_USERNAME: ${{ secrets.GH_PACKAGES_USERNAME_3DS }}
         GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_PASS_3DS }}

--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ allprojects {
     repositories {
         // ...
         mavenCentral()
-        // 3ds dependency - required
-        maven {
-            url 'https://maven.pkg.github.com/checkout/checkout-3ds-sdk-android'
-            credentials {
-                username = '<your github username>'
-                password = '<your github personal access token (classic)>'
-            }
-        }
         // ...
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 ext {
-    version = '1.5.0'
+    version = '1.6.0'
     group = "com.ryftpay"
     java_version = JavaVersion.VERSION_1_8
     kotlin_jvm_target = '1.8'

--- a/ryft-core/src/main/java/com/ryftpay/android/core/model/Ryft.kt
+++ b/ryft-core/src/main/java/com/ryftpay/android/core/model/Ryft.kt
@@ -1,6 +1,6 @@
 package com.ryftpay.android.core.model
 
 internal object Ryft {
-    internal const val VERSION = "1.5.0"
+    internal const val VERSION = "1.6.0"
     internal const val USER_AGENT = "ryft-sdk-android/$VERSION"
 }

--- a/ryft-core/src/test/java/com/ryftpay/android/core/model/RyftTest.kt
+++ b/ryft-core/src/test/java/com/ryftpay/android/core/model/RyftTest.kt
@@ -7,11 +7,11 @@ internal class RyftTest {
 
     @Test
     fun `Version should have current version of sdk`() {
-        Ryft.VERSION shouldBeEqualTo "1.5.0"
+        Ryft.VERSION shouldBeEqualTo "1.6.0"
     }
 
     @Test
     fun `User agent should identify sdk with current version`() {
-        Ryft.USER_AGENT shouldBeEqualTo "ryft-sdk-android/1.5.0"
+        Ryft.USER_AGENT shouldBeEqualTo "ryft-sdk-android/1.6.0"
     }
 }

--- a/ryft-sample-app/build.gradle
+++ b/ryft-sample-app/build.gradle
@@ -36,17 +36,6 @@ android {
     }
 }
 
-// TODO remove once ryft-android is upgraded from 1.4.0
-repositories {
-    maven {
-        url 'https://maven.pkg.github.com/checkout/checkout-3ds-sdk-android'
-        credentials {
-            username = project.findProperty("ghUsername") ?: System.getenv('GH_USERNAME')
-            password = project.findProperty("ghPackagesToken") ?: System.getenv('GH_PACKAGES_TOKEN')
-        }
-    }
-}
-
 dependencies {
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'
@@ -56,5 +45,5 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
 
     // Ryft dependency
-    implementation 'com.ryftpay:ryft-android:1.4.0'
+    implementation 'com.ryftpay:ryft-android:1.5.0'
 }


### PR DESCRIPTION
- Bump version from 1.5.0 to 1.6.0
- Bump sample app to latest released version 1.5.0
- Remove checkout maven github repository from sample app and README as it's no longer valid/required
- Rename publish.yml name to 'publish' (fix)
- Remove env vars from build jobs that are no longer required (for 3ds dependency)
- Temporarily skip ryft-sample-app from build jobs until a new version is released