### PR TITLE
[Fix] Ui tests

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ui-test:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         api-level: [ 21 ]


### PR DESCRIPTION
- Use macos-13 for job as it's the latest macos with intel CPUs (macos-latest now refers to macos-14 which uses M1) - the emulator is currently setup to run on x86 arch (default)